### PR TITLE
feat!: do not create wrap single chars in parentheses

### DIFF
--- a/docs/content/2.getting-started/3.examples.md
+++ b/docs/content/2.getting-started/3.examples.md
@@ -31,7 +31,7 @@ const TENET_RE = createRegExp(
     .and.referenceTo('secondChar')
     .and.referenceTo('firstChar')
 )
-// /(?<firstWord>\w)(?<secondWord>\w).+\k<secondWord>\k<firstWord>/
+// /(?<firstChar>\w)(?<secondChar>\w).+\k<secondChar>\k<firstChar>/
 
 assert.equal(TENET_RE.test('TEN<==O==>NET'), true)
 ```

--- a/docs/content/2.getting-started/3.examples.md
+++ b/docs/content/2.getting-started/3.examples.md
@@ -24,15 +24,14 @@ import assert from 'node:assert'
 import { createRegExp, word, char, oneOrMore } from 'magic-regexp'
 
 const TENET_RE = createRegExp(
-  word
-    .as('firstWord')
-    .and(word.as('secondWord'))
+  wordChar
+    .as('firstChar')
+    .and(wordChar.as('secondChar'))
     .and(oneOrMore(char))
-    .and.referenceTo('secondWord')
-    .and.referenceTo('firstWord')
+    .and.referenceTo('secondChar')
+    .and.referenceTo('firstChar')
 )
-// /(?<firstWord>\w)(?<secondWord>\w)(.)+\k<secondWord>\k<firstWord>/
+// /(?<firstWord>\w)(?<secondWord>\w).+\k<secondWord>\k<firstWord>/
 
 assert.equal(TENET_RE.test('TEN<==O==>NET'), true)
 ```
-

--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -2,6 +2,7 @@ import { createInput, Input } from './internal'
 import type { GetValue, EscapeChar } from './types/escape'
 import type { Join } from './types/join'
 import type { MapToGroups, MapToValues, InputSource } from './types/sources'
+import { IfSingle, wrap } from './wrap'
 
 export type { Input }
 
@@ -46,7 +47,11 @@ export const not = {
 
 /** Equivalent to `?` - this marks the input as optional */
 export const maybe = <New extends InputSource<string>>(str: New) =>
-  createInput(`(${exactly(str)})?`) as Input<`(${GetValue<New>})?`>
+  createInput(`${wrap(exactly(str))}?`) as IfSingle<
+    GetValue<New>,
+    Input<`${GetValue<New>}?`>,
+    Input<`(${GetValue<New>})?`>
+  >
 
 /** This escapes a string input to match it exactly */
 export const exactly = <New extends InputSource<string>>(input: New): Input<GetValue<New>> =>
@@ -55,4 +60,8 @@ export const exactly = <New extends InputSource<string>>(input: New): Input<GetV
     : input
 
 export const oneOrMore = <New extends InputSource<string>>(str: New) =>
-  createInput(`(${exactly(str)})+`) as Input<`(${GetValue<New>})+`>
+  createInput(`${wrap(exactly(str))}+`) as IfSingle<
+    GetValue<New>,
+    Input<`${GetValue<New>}+`>,
+    Input<`(${GetValue<New>})+`>
+  >

--- a/src/core/internal.ts
+++ b/src/core/internal.ts
@@ -1,19 +1,7 @@
 import { exactly } from './inputs'
-import type { GetValue, StripEscapes } from './types/escape'
+import type { GetValue } from './types/escape'
 import type { InputSource } from './types/sources'
-
-type IfSingle<T extends string, Yes, No> = StripEscapes<T> extends `${infer A}${infer B}`
-  ? A extends ''
-    ? Yes
-    : B extends ''
-    ? Yes
-    : No
-  : never
-
-const wrap = (s: string | Input<any>) => {
-  const v = s.toString()
-  return v.replace(/^\\/, '').length === 1 ? v : `(${v})`
-}
+import { IfSingle, wrap } from './wrap'
 
 export interface Input<V extends string, G extends string = never> {
   and: {

--- a/src/core/types/escape.ts
+++ b/src/core/types/escape.ts
@@ -20,6 +20,7 @@ type Escape<
 
 type CharEscapeCharacter = '\\' | '^' | '-' | ']'
 export type EscapeChar<T extends string> = Escape<T, CharEscapeCharacter>
+export type StripEscapes<T extends string> = T extends `${infer A}\\${infer B}` ? `${A}${B}` : T
 
 export type GetValue<T extends InputSource<string>> = T extends string
   ? Escape<T, ExactEscapeChar>

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -1,0 +1,15 @@
+import { Input } from './internal'
+import { StripEscapes } from './types/escape'
+
+export type IfSingle<T extends string, Yes, No> = StripEscapes<T> extends `${infer A}${infer B}`
+  ? A extends ''
+    ? Yes
+    : B extends ''
+    ? Yes
+    : No
+  : never
+
+export const wrap = (s: string | Input<any>) => {
+  const v = s.toString()
+  return v.replace(/^\\/, '').length === 1 ? v : `(${v})`
+}

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -135,6 +135,7 @@ describe('inputs', () => {
 
 describe('chained inputs', () => {
   const input = exactly('?')
+  const multichar = exactly('ab')
   it('and', () => {
     const val = input.and('test.js')
     const regexp = new RegExp(val as any)
@@ -180,32 +181,57 @@ describe('chained inputs', () => {
   it('times', () => {
     const val = input.times(500)
     const regexp = new RegExp(val as any)
-    expect(regexp).toMatchInlineSnapshot('/\\(\\\\\\?\\)\\{500\\}/')
-    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'(\\?){500}'>()
+    expect(regexp).toMatchInlineSnapshot('/\\\\\\?\\{500\\}/')
+    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?{500}'>()
+
+    const val2 = multichar.times(500)
+    const regexp2 = new RegExp(val as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\{500\\}/')
+    expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab){500}'>()
   })
   it('times.any', () => {
     const val = input.times.any()
     const regexp = new RegExp(val as any)
-    expect(regexp).toMatchInlineSnapshot('/\\(\\\\\\?\\)\\*/')
-    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'(\\?)*'>()
+    expect(regexp).toMatchInlineSnapshot('/\\\\\\?\\*/')
+    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?*'>()
+
+    const val2 = multichar.times.any()
+    const regexp2 = new RegExp(val as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\*/')
+    expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab)*'>()
   })
   it('times.atLeast', () => {
     const val = input.times.atLeast(2)
     const regexp = new RegExp(val as any)
-    expect(regexp).toMatchInlineSnapshot('/\\(\\\\\\?\\)\\{2,\\}/')
-    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'(\\?){2,}'>()
+    expect(regexp).toMatchInlineSnapshot('/\\\\\\?\\{2,\\}/')
+    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?{2,}'>()
+
+    const val2 = multichar.times.atLeast(2)
+    const regexp2 = new RegExp(val as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\{2,\\}/')
+    expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab){2,}'>()
   })
   it('times.between', () => {
     const val = input.times.between(3, 5)
     const regexp = new RegExp(val as any)
-    expect(regexp).toMatchInlineSnapshot('/\\(\\\\\\?\\)\\{3,5\\}/')
-    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'(\\?){3,5}'>()
+    expect(regexp).toMatchInlineSnapshot('/\\\\\\?\\{3,5\\}/')
+    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?{3,5}'>()
+
+    const val2 = multichar.times.between(3, 5)
+    const regexp2 = new RegExp(val as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\{3,5\\}/')
+    expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab){3,5}'>()
   })
   it('optionally', () => {
     const val = input.optionally()
     const regexp = new RegExp(val as any)
-    expect(regexp).toMatchInlineSnapshot('/\\(\\\\\\?\\)\\?/')
-    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'(\\?)?'>()
+    expect(regexp).toMatchInlineSnapshot('/\\\\\\?\\?/')
+    expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\??'>()
+
+    const val2 = multichar.optionally()
+    const regexp2 = new RegExp(val as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\?/')
+    expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab)?'>()
   })
   it('as', () => {
     const val = input.as('test')

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -185,8 +185,8 @@ describe('chained inputs', () => {
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?{500}'>()
 
     const val2 = multichar.times(500)
-    const regexp2 = new RegExp(val as any)
-    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\{500\\}/')
+    const regexp2 = new RegExp(val2 as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\(ab\\)\\{500\\}/')
     expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab){500}'>()
   })
   it('times.any', () => {
@@ -196,8 +196,8 @@ describe('chained inputs', () => {
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?*'>()
 
     const val2 = multichar.times.any()
-    const regexp2 = new RegExp(val as any)
-    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\*/')
+    const regexp2 = new RegExp(val2 as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\(ab\\)\\*/')
     expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab)*'>()
   })
   it('times.atLeast', () => {
@@ -207,8 +207,8 @@ describe('chained inputs', () => {
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?{2,}'>()
 
     const val2 = multichar.times.atLeast(2)
-    const regexp2 = new RegExp(val as any)
-    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\{2,\\}/')
+    const regexp2 = new RegExp(val2 as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\(ab\\)\\{2,\\}/')
     expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab){2,}'>()
   })
   it('times.between', () => {
@@ -218,8 +218,8 @@ describe('chained inputs', () => {
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?{3,5}'>()
 
     const val2 = multichar.times.between(3, 5)
-    const regexp2 = new RegExp(val as any)
-    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\{3,5\\}/')
+    const regexp2 = new RegExp(val2 as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\(ab\\)\\{3,5\\}/')
     expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab){3,5}'>()
   })
   it('optionally', () => {
@@ -229,8 +229,8 @@ describe('chained inputs', () => {
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\??'>()
 
     const val2 = multichar.optionally()
-    const regexp2 = new RegExp(val as any)
-    expect(regexp2).toMatchInlineSnapshot('/\\\\\\?\\?/')
+    const regexp2 = new RegExp(val2 as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\(ab\\)\\?/')
     expectTypeOf(extractRegExp(val2)).toEqualTypeOf<'(ab)?'>()
   })
   it('as', () => {


### PR DESCRIPTION
resolves https://github.com/danielroe/magic-regexp/issues/28

BREAKING CHANGE: single chars chained with `times`, `times.any()`, `times.atLeast()`, `times.between()` and `.optionally()`, as well as single inputs passed in to `oneOrMore` and `maybe` will no longer be wrapped in brackets