### PR TITLE
fix: order of generic types for param of `createInput`

### DIFF
--- a/src/core/internal.ts
+++ b/src/core/internal.ts
@@ -53,7 +53,7 @@ export interface Input<V extends string, G extends string = never> {
 }
 
 export const createInput = <Value extends string, Groups extends string = never>(
-  s: Value | Input<Groups, Value>
+  s: Value | Input<Value, Groups>
 ): Input<Value, Groups> => {
   return {
     toString: () => s.toString(),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -31,6 +31,11 @@ describe('inputs', () => {
   it('createInput serializes to string', () => {
     expect(`${createInput('\\s')}`).toEqual('\\s')
   })
+  it('type infer group names when nesting createInput', () => {
+    expectTypeOf(createRegExp(createInput(exactly('\\s').as('groupName')))).toEqualTypeOf<
+      MagicRegExp<'/(?<groupName>\\s)/', 'groupName', never>
+    >()
+  })
   it('any', () => {
     const regExp = createRegExp(anyOf('foo', 'bar'))
     expect(regExp).toMatchInlineSnapshot('/\\(foo\\|bar\\)/')


### PR DESCRIPTION
Type for parameters in `createInput` have generics in swapped position:
`Input<Groups, Value>` instead of `Input<Value, Groups>`


```ts
export const createInput = <Value extends string, Groups extends string = never>(
  s: Value | Input<Groups, Value>
): Input<Value, Groups>
```

also, add a type level test for checking group names when passing other `Input` with group names into `createInput`

```ts
expectTypeOf(
createRegExp(createInput(exactly('\\s').as('groupName')))
).toEqualTypeOf<
      MagicRegExp<'/(?<groupName>\\s)/', 'groupName', never>
    >()
```