### PR TITLE
fix: infer group names from param with `Input` type

### DIFF
--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -1,7 +1,7 @@
 import { createInput, Input } from './internal'
 import type { GetValue, EscapeChar } from './types/escape'
 import type { Join } from './types/join'
-import type { MapToGroups, MapToValues, InputSource } from './types/sources'
+import type { MapToGroups, MapToValues, InputSource, GetGroup } from './types/sources'
 import { IfSingle, wrap } from './wrap'
 
 export type { Input }
@@ -49,12 +49,14 @@ export const not = {
 export const maybe = <New extends InputSource<string>>(str: New) =>
   createInput(`${wrap(exactly(str))}?`) as IfSingle<
     GetValue<New>,
-    Input<`${GetValue<New>}?`>,
-    Input<`(${GetValue<New>})?`>
+    Input<`${GetValue<New>}?`, GetGroup<New>>,
+    Input<`(${GetValue<New>})?`, GetGroup<New>>
   >
 
 /** This escapes a string input to match it exactly */
-export const exactly = <New extends InputSource<string>>(input: New): Input<GetValue<New>> =>
+export const exactly = <New extends InputSource<string>>(
+  input: New
+): Input<GetValue<New>, GetGroup<New>> =>
   typeof input === 'string'
     ? (createInput(input.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')) as any)
     : input
@@ -62,6 +64,6 @@ export const exactly = <New extends InputSource<string>>(input: New): Input<GetV
 export const oneOrMore = <New extends InputSource<string>>(str: New) =>
   createInput(`${wrap(exactly(str))}+`) as IfSingle<
     GetValue<New>,
-    Input<`${GetValue<New>}+`>,
-    Input<`(${GetValue<New>})+`>
+    Input<`${GetValue<New>}+`, GetGroup<New>>,
+    Input<`(${GetValue<New>})+`, GetGroup<New>>
   >

--- a/src/core/types/sources.ts
+++ b/src/core/types/sources.ts
@@ -2,6 +2,9 @@ import type { Input } from '../internal'
 import type { GetValue } from './escape'
 
 export type InputSource<S extends string = never, T extends string = never> = S | Input<S, T>
+export type GetGroup<T extends InputSource<string>> = T extends Input<string, infer Group>
+  ? Group
+  : never
 export type MapToValues<T extends InputSource<any, any>[]> = T extends [infer First, ...infer Rest]
   ? First extends InputSource<string>
     ? [GetValue<First>, ...MapToValues<Rest>]

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -21,6 +21,7 @@ import {
   carriageReturn,
   charNotIn,
 } from '../src/core/inputs'
+import { createRegExp, MagicRegExp } from '../src'
 
 describe('inputs', () => {
   it('charIn', () => {
@@ -54,12 +55,20 @@ describe('inputs', () => {
     const regexp = new RegExp(input as any)
     expect(regexp).toMatchInlineSnapshot('/\\(foo\\)\\?/')
     expectTypeOf(extractRegExp(input)).toEqualTypeOf<'(foo)?'>()
+    const nestedInputWithGroup = maybe(exactly('foo').as('groupName'))
+    expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
+      MagicRegExp<'/((?<groupName>foo))?/', 'groupName', never>
+    >()
   })
   it('oneOrMore', () => {
     const input = oneOrMore('foo')
     const regexp = new RegExp(input as any)
     expect(regexp).toMatchInlineSnapshot('/\\(foo\\)\\+/')
     expectTypeOf(extractRegExp(input)).toEqualTypeOf<'(foo)+'>()
+    const nestedInputWithGroup = oneOrMore(exactly('foo').as('groupName'))
+    expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
+      MagicRegExp<'/((?<groupName>foo))+/', 'groupName', never>
+    >()
   })
   it('exactly', () => {
     const input = exactly('fo?[a-z]{2}/o?')
@@ -67,6 +76,10 @@ describe('inputs', () => {
       '/fo\\\\\\?\\\\\\[a-z\\\\\\]\\\\\\{2\\\\\\}\\\\/o\\\\\\?/'
     )
     expectTypeOf(extractRegExp(input)).toEqualTypeOf<'fo\\?\\[a-z\\]\\{2\\}\\/o\\?'>()
+    const nestedInputWithGroup = exactly(maybe('foo').and('bar').as('groupName'))
+    expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
+      MagicRegExp<'/(?<groupName>(foo)?bar)/', 'groupName', never>
+    >()
   })
   it('word', () => {
     const input = word


### PR DESCRIPTION
Types for helper functions `exactly`, `maybe`, `oneOrMore` does not  infer group names from param with `Input` type

```ts
 <New extends InputSource<string>>(
  input: New
): Input<GetValue<New>>

// example
const pattern = oneOrMore(exactly('foo').as('fooGroup'))
// pattern: Input<"((?<fooGroup>foo))+", never> // should be Input<"((?<fooGroup>foo))+", "fooGroup">
```