### PR TITLE
feat: update `IfSingle` and `wrap` to not wrap wrapped input

### DIFF
--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -2,7 +2,7 @@ import { createInput, Input } from './internal'
 import type { GetValue, EscapeChar } from './types/escape'
 import type { Join } from './types/join'
 import type { MapToGroups, MapToValues, InputSource, GetGroup } from './types/sources'
-import { IfSingle, wrap } from './wrap'
+import { Wrap, wrap } from './wrap'
 
 export type { Input }
 
@@ -47,7 +47,7 @@ export const not = {
 
 /** Equivalent to `?` - this marks the input as optional */
 export const maybe = <New extends InputSource<string>>(str: New) =>
-  createInput(`${wrap(exactly(str))}?`) as IfSingle<
+  createInput(`${wrap(exactly(str))}?`) as Wrap<
     GetValue<New>,
     Input<`${GetValue<New>}?`, GetGroup<New>>,
     Input<`(${GetValue<New>})?`, GetGroup<New>>
@@ -62,7 +62,7 @@ export const exactly = <New extends InputSource<string>>(
     : input
 
 export const oneOrMore = <New extends InputSource<string>>(str: New) =>
-  createInput(`${wrap(exactly(str))}+`) as IfSingle<
+  createInput(`${wrap(exactly(str))}+`) as Wrap<
     GetValue<New>,
     Input<`${GetValue<New>}+`, GetGroup<New>>,
     Input<`(${GetValue<New>})+`, GetGroup<New>>

--- a/src/core/internal.ts
+++ b/src/core/internal.ts
@@ -1,7 +1,7 @@
 import { exactly } from './inputs'
 import type { GetValue } from './types/escape'
 import type { InputSource } from './types/sources'
-import { IfSingle, wrap } from './wrap'
+import { Wrap, wrap } from './wrap'
 
 export interface Input<V extends string, G extends string = never> {
   and: {
@@ -30,18 +30,18 @@ export interface Input<V extends string, G extends string = never> {
   notBefore: <I extends InputSource<string>>(input: I) => Input<`${V}(?!${GetValue<I>})`, G>
   times: {
     /** repeat the previous pattern an exact number of times */
-    <N extends number>(number: N): IfSingle<V, Input<`${V}{${N}}`, G>, Input<`(${V}){${N}}`, G>>
+    <N extends number>(number: N): Wrap<V, Input<`${V}{${N}}`, G>, Input<`(${V}){${N}}`, G>>
     /** specify that the expression can repeat any number of times, _including none_ */
-    any: () => IfSingle<V, Input<`${V}*`, G>, Input<`(${V})*`, G>>
+    any: () => Wrap<V, Input<`${V}*`, G>, Input<`(${V})*`, G>>
     /** specify that the expression must occur at least x times */
     atLeast: <N extends number>(
       number: N
-    ) => IfSingle<V, Input<`${V}{${N},}`, G>, Input<`(${V}){${N},}`, G>>
+    ) => Wrap<V, Input<`${V}{${N},}`, G>, Input<`(${V}){${N},}`, G>>
     /** specify a range of times to repeat the previous pattern */
     between: <Min extends number, Max extends number>(
       min: Min,
       max: Max
-    ) => IfSingle<V, Input<`${V}{${Min},${Max}}`, G>, Input<`(${V}){${Min},${Max}}`, G>>
+    ) => Wrap<V, Input<`${V}{${Min},${Max}}`, G>, Input<`(${V}){${Min},${Max}}`, G>>
   }
   /** this defines the entire input so far as a named capture group. You will get type safety when using the resulting RegExp with `String.match()` */
   as: <K extends string>(key: K) => Input<`(?<${K}>${V})`, G | K>
@@ -51,7 +51,7 @@ export interface Input<V extends string, G extends string = never> {
     lineEnd: () => Input<`${V}$`, G>
   }
   /** this allows you to mark the input so far as optional */
-  optionally: () => IfSingle<V, Input<`${V}?`, G>, Input<`(${V})?`, G>>
+  optionally: () => Wrap<V, Input<`${V}?`, G>, Input<`(${V})?`, G>>
   toString: () => string
 }
 

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -1,7 +1,7 @@
 import { Input } from './internal'
 import { StripEscapes } from './types/escape'
 
-export type IfSingle<T extends string, Yes, No> = T extends `(${string})`
+export type Wrap<T extends string, Yes, No> = T extends `(${string})`
   ? Yes
   : StripEscapes<T> extends `${infer A}${infer B}`
   ? A extends ''

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -13,5 +13,5 @@ export type Wrap<T extends string, Yes, No> = T extends `(${string})`
 
 export const wrap = (s: string | Input<any>) => {
   const v = s.toString()
-  return /(?<!\\)(\().*(?<!\\)(\))/.test(v) || v.replace(/^\\/, '').length === 1 ? v : `(${v})`
+  return /^((?<!\\)(\().*(?<!\\)(\))|.|\\[^()])$/.test(v) ? v : `(${v})`
 }

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -11,7 +11,9 @@ export type Wrap<T extends string, Yes, No> = T extends `(${string})`
     : No
   : never
 
+const NEEDS_WRAP_RE = /^(\(.*\)|\\?.)$/
+
 export const wrap = (s: string | Input<any>) => {
   const v = s.toString()
-  return /^((?<!\\)(\().*(?<!\\)(\))|.|\\[^()])$/.test(v) ? v : `(${v})`
+  return NEEDS_WRAP_RE.test(v) ? v : `(${v})`
 }

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -1,7 +1,9 @@
 import { Input } from './internal'
 import { StripEscapes } from './types/escape'
 
-export type IfSingle<T extends string, Yes, No> = StripEscapes<T> extends `${infer A}${infer B}`
+export type IfSingle<T extends string, Yes, No> = T extends `(${string})`
+  ? Yes
+  : StripEscapes<T> extends `${infer A}${infer B}`
   ? A extends ''
     ? Yes
     : B extends ''
@@ -11,5 +13,5 @@ export type IfSingle<T extends string, Yes, No> = StripEscapes<T> extends `${inf
 
 export const wrap = (s: string | Input<any>) => {
   const v = s.toString()
-  return v.replace(/^\\/, '').length === 1 ? v : `(${v})`
+  return /(?<!\\)(\().*(?<!\\)(\))/.test(v) || v.replace(/^\\/, '').length === 1 ? v : `(${v})`
 }

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -57,7 +57,7 @@ describe('inputs', () => {
     expectTypeOf(extractRegExp(input)).toEqualTypeOf<'(foo)?'>()
     const nestedInputWithGroup = maybe(exactly('foo').as('groupName'))
     expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
-      MagicRegExp<'/((?<groupName>foo))?/', 'groupName', never>
+      MagicRegExp<'/(?<groupName>foo)?/', 'groupName', never>
     >()
   })
   it('oneOrMore', () => {
@@ -67,7 +67,7 @@ describe('inputs', () => {
     expectTypeOf(extractRegExp(input)).toEqualTypeOf<'(foo)+'>()
     const nestedInputWithGroup = oneOrMore(exactly('foo').as('groupName'))
     expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
-      MagicRegExp<'/((?<groupName>foo))+/', 'groupName', never>
+      MagicRegExp<'/(?<groupName>foo)+/', 'groupName', never>
     >()
   })
   it('exactly', () => {
@@ -143,6 +143,12 @@ describe('inputs', () => {
     expectTypeOf(extractRegExp(not.linefeed)).toEqualTypeOf<'[^\\n]'>()
     expect(not.carriageReturn.toString()).toMatchInlineSnapshot('"[^\\\\r]"')
     expectTypeOf(extractRegExp(not.carriageReturn)).toEqualTypeOf<'[^\\r]'>()
+  })
+  it('no extra wrap by ()', () => {
+    const input = oneOrMore(maybe(exactly('(foo)')).as('groupName'))
+    const regexp = new RegExp(input as any)
+    expect(regexp).toMatchInlineSnapshot('/\\(\\?<groupName>\\(\\\\\\(foo\\\\\\)\\)\\?\\)\\+/')
+    expectTypeOf(extractRegExp(input)).toEqualTypeOf<'(?<groupName>(\\(foo\\))?)+'>()
   })
 })
 


### PR DESCRIPTION
`IfSingle` type and `wrap` helper function still wrap input which is already wrapped with `( )`

```ts
oneOrMore(exactly('a').as('groupName')) // ((?<groupName>a))+
```

and rename `IfSingle` type to `Wrap`