### PR TITLE
feat: type safe match array access with refer hint

### DIFF
--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -1,7 +1,14 @@
 import { createInput, Input } from './internal'
 import type { GetValue, EscapeChar } from './types/escape'
 import type { Join } from './types/join'
-import type { MapToGroups, MapToValues, InputSource, GetGroup } from './types/sources'
+import type {
+  MapToGroups,
+  MapToValues,
+  InputSource,
+  GetGroup,
+  MapToCapturedGroupsArr,
+  GetCapturedGroupsArr,
+} from './types/sources'
 import { IfUnwrapped, wrap } from './wrap'
 
 export type { Input }
@@ -20,7 +27,8 @@ export const charNotIn = <T extends string>(chars: T) =>
 export const anyOf = <New extends InputSource<string, string>[]>(...args: New) =>
   createInput(`(?:${args.map(a => exactly(a)).join('|')})`) as Input<
     `(?:${Join<MapToValues<New>>})`,
-    MapToGroups<New>
+    MapToGroups<New>,
+    MapToCapturedGroupsArr<New>
   >
 
 export const char = createInput('.')
@@ -49,20 +57,20 @@ export const not = {
 export const maybe = <New extends InputSource<string>>(str: New) =>
   createInput(`${wrap(exactly(str))}?`) as IfUnwrapped<
     GetValue<New>,
-    Input<`(?:${GetValue<New>})?`, GetGroup<New>>,
-    Input<`${GetValue<New>}?`, GetGroup<New>>
+    Input<`(?:${GetValue<New>})?`, GetGroup<New>, GetCapturedGroupsArr<New>>,
+    Input<`${GetValue<New>}?`, GetGroup<New>, GetCapturedGroupsArr<New>>
   >
 
 /** This escapes a string input to match it exactly */
 export const exactly = <New extends InputSource<string>>(
   input: New
-): Input<GetValue<New>, GetGroup<New>> =>
+): Input<GetValue<New>, GetGroup<New>, GetCapturedGroupsArr<New>> =>
   typeof input === 'string' ? (createInput(input.replace(ESCAPE_REPLACE_RE, '\\$&')) as any) : input
 
 /** Equivalent to `+` - this marks the input as repeatable, any number of times but at least once */
 export const oneOrMore = <New extends InputSource<string>>(str: New) =>
   createInput(`${wrap(exactly(str))}+`) as IfUnwrapped<
     GetValue<New>,
-    Input<`(?:${GetValue<New>})+`, GetGroup<New>>,
-    Input<`${GetValue<New>}+`, GetGroup<New>>
+    Input<`(?:${GetValue<New>})+`, GetGroup<New>, GetCapturedGroupsArr<New>>,
+    Input<`${GetValue<New>}+`, GetGroup<New>, GetCapturedGroupsArr<New>>
   >

--- a/src/core/internal.ts
+++ b/src/core/internal.ts
@@ -1,78 +1,108 @@
 import { exactly } from './inputs'
 import type { GetValue } from './types/escape'
-import type { InputSource } from './types/sources'
+import type { GetCapturedGroupsArr, InputSource } from './types/sources'
 import { IfUnwrapped, wrap } from './wrap'
 
 const GROUPED_AS_REPLACE_RE = /^(?:\(\?:(.+)\)|(\(?.+\)?))$/
-const GROUPED_REPLACE_RE = /^(?:\(\??:?(.+)\)([?+*]|{[\d,]+})?|(.+))$/
+const GROUPED_REPLACE_RE = /^(?:\(\?:(.+)\)([?+*]|{[\d,]+})?|(.+))$/
 
-export interface Input<V extends string, G extends string = never> {
+export interface Input<
+  V extends string,
+  G extends string = never,
+  C extends (string | undefined)[] = []
+> {
   and: {
     /** this adds a new pattern to the current input */
     <I extends InputSource<string, any>>(input: I): Input<
       `${V}${GetValue<I>}`,
-      G | (I extends Input<any, infer NewGroups> ? NewGroups : never)
+      G | (I extends Input<any, infer NewGroups> ? NewGroups : never),
+      [...C, ...GetCapturedGroupsArr<I>]
     >
     /** this adds a new pattern to the current input, with the pattern reference to a named group. */
-    referenceTo: <N extends G>(groupName: N) => Input<`${V}\\k<${N}>`, G>
+    referenceTo: <N extends G>(groupName: N) => Input<`${V}\\k<${N}>`, G, C>
   }
   /** this provides an alternative to the current input */
   or: <I extends InputSource<string, any>>(
     input: I
   ) => Input<
     `(?:${V}|${GetValue<I>})`,
-    G | (I extends Input<any, infer NewGroups> ? NewGroups : never)
+    G | (I extends Input<any, infer NewGroups> ? NewGroups : never),
+    [...C, ...GetCapturedGroupsArr<I>]
   >
   /** this is a positive lookbehind. Make sure to check [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility) as not all browsers support lookbehinds (notably Safari) */
-  after: <I extends InputSource<string>>(input: I) => Input<`(?<=${GetValue<I>})${V}`, G>
+  after: <I extends InputSource<string>>(
+    input: I
+  ) => Input<`(?<=${GetValue<I>})${V}`, G, [...GetCapturedGroupsArr<I>, ...C]>
   /** this is a positive lookahead */
-  before: <I extends InputSource<string>>(input: I) => Input<`${V}(?=${GetValue<I>})`, G>
+  before: <I extends InputSource<string>>(
+    input: I
+  ) => Input<`${V}(?=${GetValue<I>})`, G, [...C, ...GetCapturedGroupsArr<I>]>
   /** these is a negative lookbehind. Make sure to check [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility) as not all browsers support lookbehinds (notably Safari) */
-  notAfter: <I extends InputSource<string>>(input: I) => Input<`(?<!${GetValue<I>})${V}`, G>
+  notAfter: <I extends InputSource<string>>(
+    input: I
+  ) => Input<`(?<!${GetValue<I>})${V}`, G, [...GetCapturedGroupsArr<I, true>, ...C]>
   /** this is a negative lookahead */
-  notBefore: <I extends InputSource<string>>(input: I) => Input<`${V}(?!${GetValue<I>})`, G>
+  notBefore: <I extends InputSource<string>>(
+    input: I
+  ) => Input<`${V}(?!${GetValue<I>})`, G, [...C, ...GetCapturedGroupsArr<I, true>]>
   times: {
     /** repeat the previous pattern an exact number of times */
     <N extends number>(number: N): IfUnwrapped<
       V,
-      Input<`(?:${V}){${N}}`, G>,
-      Input<`${V}{${N}}`, G>
+      Input<`(?:${V}){${N}}`, G, C>,
+      Input<`${V}{${N}}`, G, C>
     >
     /** specify that the expression can repeat any number of times, _including none_ */
-    any: () => IfUnwrapped<V, Input<`(?:${V})*`, G>, Input<`${V}*`, G>>
+    any: () => IfUnwrapped<V, Input<`(?:${V})*`, G>, Input<`${V}*`, G, C>>
     /** specify that the expression must occur at least x times */
     atLeast: <N extends number>(
       number: N
-    ) => IfUnwrapped<V, Input<`(?:${V}){${N},}`, G>, Input<`${V}{${N},}`, G>>
+    ) => IfUnwrapped<V, Input<`(?:${V}){${N},}`, G>, Input<`${V}{${N},}`, G, C>>
     /** specify a range of times to repeat the previous pattern */
     between: <Min extends number, Max extends number>(
       min: Min,
       max: Max
-    ) => IfUnwrapped<V, Input<`(?:${V}){${Min},${Max}}`, G>, Input<`${V}{${Min},${Max}}`, G>>
+    ) => IfUnwrapped<V, Input<`(?:${V}){${Min},${Max}}`, G, C>, Input<`${V}{${Min},${Max}}`, G, C>>
   }
   /** this defines the entire input so far as a named capture group. You will get type safety when using the resulting RegExp with `String.match()`. Alias for `groupedAs` */
   as: <K extends string>(
     key: K
-  ) => Input<`(?<${K}>${V extends `(?:${infer S extends string})` ? S : V})`, G | K>
+  ) => Input<
+    `(?<${K}>${V extends `(?:${infer S})` ? S : V})`,
+    G | K,
+    [`(?<${K}>${V extends `(?:${infer S})` ? S : V})`, ...C]
+  >
   /** this defines the entire input so far as a named capture group. You will get type safety when using the resulting RegExp with `String.match()` */
   groupedAs: <K extends string>(
     key: K
-  ) => Input<`(?<${K}>${V extends `(?:${infer S extends string})` ? S : V})`, G | K>
+  ) => Input<
+    `(?<${K}>${V extends `(?:${infer S})` ? S : V})`,
+    G | K,
+    [`(?<${K}>${V extends `(?:${infer S})` ? S : V})`, ...C]
+  >
   /** this capture the entire input so far as an anonymous group */
-  grouped: () => Input<V extends `(?:${infer S})${infer E}` ? `(${S})${E}` : `(${V})`, G>
+  grouped: () => Input<
+    V extends `(?:${infer S})${infer E}` ? `(${S})${E}` : `(${V})`,
+    G,
+    [V extends `(?:${infer S})${'' | '?' | '+' | '*' | `{${string}}`}` ? `(${S})` : `(${V})`, ...C]
+  >
   /** this allows you to match beginning/ends of lines with `at.lineStart()` and `at.lineEnd()` */
   at: {
-    lineStart: () => Input<`^${V}`, G>
-    lineEnd: () => Input<`${V}$`, G>
+    lineStart: () => Input<`^${V}`, G, C>
+    lineEnd: () => Input<`${V}$`, G, C>
   }
   /** this allows you to mark the input so far as optional */
-  optionally: () => IfUnwrapped<V, Input<`(?:${V})?`, G>, Input<`${V}?`, G>>
+  optionally: () => IfUnwrapped<V, Input<`(?:${V})?`, G, C>, Input<`${V}?`, G, C>>
   toString: () => string
 }
 
-export const createInput = <Value extends string, Groups extends string = never>(
-  s: Value | Input<Value, Groups>
-): Input<Value, Groups> => {
+export const createInput = <
+  Value extends string,
+  Groups extends string = never,
+  CaptureGroupsArr extends (string | undefined)[] = []
+>(
+  s: Value | Input<Value, Groups, CaptureGroupsArr>
+): Input<Value, Groups, CaptureGroupsArr> => {
   const groupedAsFn = (key: string) =>
     createInput(`(?<${key}>${`${s}`.replace(GROUPED_AS_REPLACE_RE, '$1$2')})`)
 

--- a/src/core/types/magic-regexp.ts
+++ b/src/core/types/magic-regexp.ts
@@ -1,28 +1,40 @@
 const NamedGroupsS = Symbol('NamedGroups')
 const ValueS = Symbol('Value')
+const CapturedGroupsArrS = Symbol('CapturedGroupsArr')
 const FlagsS = Symbol('Flags')
 
 export type MagicRegExp<
   Value extends string,
   NamedGroups extends string | never = never,
+  CapturedGroupsArr extends (string | undefined)[] = [],
   Flags extends string | never = never
 > = RegExp & {
   [NamedGroupsS]: NamedGroups
+  [CapturedGroupsArrS]: CapturedGroupsArr
   [ValueS]: Value
   [FlagsS]: Flags
 }
 
-type ExtractGroups<T extends MagicRegExp<string, string, string>> = T extends MagicRegExp<
-  string,
-  infer V,
-  string
->
-  ? V
-  : never
+type ExtractGroups<T extends MagicRegExp<string, string, (string | undefined)[], string>> =
+  T extends MagicRegExp<string, infer V, (string | undefined)[], string> ? V : never
 
-export type MagicRegExpMatchArray<T extends MagicRegExp<string, string, string>> = Omit<
+type StringWithHint<S extends string> = string & {
+  _captureBy: S
+}
+
+export type StringCaptureBy<S extends string> = StringWithHint<S>
+
+export type MapToStringCaptureBy<Ar extends (string | undefined)[]> = {
+  [K in keyof Ar]: Ar[K] extends string ? StringCaptureBy<Ar[K]> | undefined : undefined
+}
+
+export type MagicRegExpMatchArray<T extends MagicRegExp<string, string, any[], string>> = Omit<
   RegExpMatchArray,
   'groups'
 > & {
   groups: Record<ExtractGroups<T>, string | undefined>
-}
+} & {
+  [index: number | string | symbol]: never
+} & (T extends MagicRegExp<string, string, infer CapturedGroupsArr, string>
+    ? readonly [string | undefined, ...MapToStringCaptureBy<CapturedGroupsArr>]
+    : {})

--- a/src/core/types/sources.ts
+++ b/src/core/types/sources.ts
@@ -5,6 +5,14 @@ export type InputSource<S extends string = never, T extends string = never> = S 
 export type GetGroup<T extends InputSource<string>> = T extends Input<string, infer Group>
   ? Group
   : never
+export type GetCapturedGroupsArr<
+  T extends InputSource<string>,
+  MapToUndefined extends boolean = false
+> = T extends Input<string, any, infer CapturedGroupArr>
+  ? MapToUndefined extends true
+    ? { [K in keyof CapturedGroupArr]: undefined }
+    : CapturedGroupArr
+  : []
 export type MapToValues<T extends InputSource<any, any>[]> = T extends [infer First, ...infer Rest]
   ? First extends InputSource<string>
     ? [GetValue<First>, ...MapToValues<Rest>]
@@ -19,3 +27,13 @@ export type MapToGroups<T extends InputSource<any, string>[]> = T extends [
     ? K | MapToGroups<Rest>
     : MapToGroups<Rest>
   : never
+
+type Flatten<T extends any[]> = T extends [infer L, ...infer R]
+  ? L extends any[]
+    ? [...Flatten<L>, ...Flatten<R>]
+    : [L, ...Flatten<R>]
+  : []
+
+export type MapToCapturedGroupsArr<T extends InputSource<any, string>[]> = Flatten<{
+  [K in keyof T]: T[K] extends Input<any, any, infer C> ? C : string[]
+}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,16 @@ import type { MagicRegExp, MagicRegExpMatchArray } from './core/types/magic-rege
 export const createRegExp = <
   Value extends string,
   NamedGroups extends string = never,
+  CapturedGroupsArr extends (string | undefined)[] = [],
   Flags extends Flag[] = never[]
 >(
-  raw: Input<Value, NamedGroups> | Value,
+  raw: Input<Value, NamedGroups, CapturedGroupsArr> | Value,
   flags?: [...Flags] | string | Set<Flag>
 ) =>
   new RegExp(exactly(raw).toString(), [...(flags || '')].join('')) as MagicRegExp<
     `/${Value}/${Join<Flags, '', ''>}`,
     NamedGroups,
+    CapturedGroupsArr,
     Flags[number]
   >
 
@@ -24,27 +26,31 @@ export * from './core/types/magic-regexp'
 // Add additional overload to global String object types to allow for typed capturing groups
 declare global {
   interface String {
-    match<R extends MagicRegExp<string, string, Exclude<Flag, 'g'>>>(
+    match<R extends MagicRegExp<string, string, (string | undefined)[], Exclude<Flag, 'g'>>>(
       regexp: R
     ): MagicRegExpMatchArray<R> | null
-    match<R extends MagicRegExp<string, string, 'g'>>(regexp: R): string[] | null
+    match<R extends MagicRegExp<string, string, (string | undefined)[], 'g'>>(
+      regexp: R
+    ): string[] | null
 
     /** @deprecated String.matchAll requires global flag to be set. */
-    matchAll<R extends MagicRegExp<string, string, never>>(regexp: R): never
+    matchAll<R extends MagicRegExp<string, string, (string | undefined)[], never>>(regexp: R): never
     /** @deprecated String.matchAll requires global flag to be set. */
-    matchAll<R extends MagicRegExp<string, string, Exclude<Flag, 'g'>>>(regexp: R): never
+    matchAll<R extends MagicRegExp<string, string, (string | undefined)[], Exclude<Flag, 'g'>>>(
+      regexp: R
+    ): never
 
-    matchAll<R extends MagicRegExp<string, string, string>>(
+    matchAll<R extends MagicRegExp<string, string, (string | undefined)[], string>>(
       regexp: R
     ): IterableIterator<MagicRegExpMatchArray<R>>
 
     /** @deprecated String.replaceAll requires global flag to be set. */
-    replaceAll<R extends MagicRegExp<string, string, never>>(
+    replaceAll<R extends MagicRegExp<string, string, (string | undefined)[], never>>(
       searchValue: R,
       replaceValue: string | ((substring: string, ...args: any[]) => string)
     ): never
     /** @deprecated String.replaceAll requires global flag to be set. */
-    replaceAll<R extends MagicRegExp<string, string, Exclude<Flag, 'g'>>>(
+    replaceAll<R extends MagicRegExp<string, string, (string | undefined)[], Exclude<Flag, 'g'>>>(
       searchValue: R,
       replaceValue: string | ((substring: string, ...args: any[]) => string)
     ): never

--- a/test/augments.test.ts
+++ b/test/augments.test.ts
@@ -9,7 +9,7 @@ describe('String', () => {
     expect(Array.isArray(result)).toBeTruthy()
     expect(result?.groups?.foo).toEqual('t')
     expectTypeOf(result).toEqualTypeOf<MagicRegExpMatchArray<
-      MagicRegExp<'/(?<foo>.)/', 'foo', never>
+      MagicRegExp<'/(?<foo>.)/', 'foo', ['(?<foo>.)'], never>
     > | null>()
   })
   it('.match global', () => {
@@ -31,7 +31,7 @@ describe('String', () => {
       count++
       expect([...'test'].includes(result?.groups.foo || '')).toBeTruthy()
       expectTypeOf(result).toEqualTypeOf<
-        MagicRegExpMatchArray<MagicRegExp<'/(?<foo>.)/g', 'foo', 'g'>>
+        MagicRegExpMatchArray<MagicRegExp<'/(?<foo>.)/g', 'foo', ['(?<foo>.)'], 'g'>>
       >()
     }
     expect(count).toBe(4)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,11 +6,13 @@ import {
   char,
   createRegExp,
   exactly,
+  maybe,
   global,
   digit,
   multiline,
   MagicRegExp,
   MagicRegExpMatchArray,
+  StringCaptureBy,
 } from '../src'
 import { createInput } from '../src/core/internal'
 
@@ -24,7 +26,7 @@ describe('magic-regexp', () => {
   })
   it('collects flag type', () => {
     const re = createRegExp('.', [global, multiline])
-    expectTypeOf(re).toEqualTypeOf<MagicRegExp<'/./gm', never, 'g' | 'm'>>()
+    expectTypeOf(re).toEqualTypeOf<MagicRegExp<'/./gm', never, [], 'g' | 'm'>>()
   })
 })
 
@@ -34,7 +36,7 @@ describe('inputs', () => {
   })
   it('type infer group names when nesting createInput', () => {
     expectTypeOf(createRegExp(createInput(exactly('\\s').groupedAs('groupName')))).toEqualTypeOf<
-      MagicRegExp<'/(?<groupName>\\s)/', 'groupName', never>
+      MagicRegExp<'/(?<groupName>\\s)/', 'groupName', ['(?<groupName>\\s)'], never>
     >()
   })
   it('any', () => {
@@ -142,5 +144,43 @@ describe('inputs', () => {
     expectTypeOf(pattern.and.referenceTo).toBeCallableWith('barGroup')
     // @ts-expect-error
     pattern.and.referenceTo('bazgroup')
+  })
+  it('can type-safe access matched array with hint for corresponding capture group', () => {
+    const pattern = anyOf(
+      exactly('foo|?').grouped(),
+      exactly('bar').and(maybe('baz').grouped()).groupedAs('groupName'),
+      exactly('boo').times(2).grouped(),
+      anyOf(
+        exactly('a').times(3),
+        exactly('b').and(maybe('c|d?')).times.any(),
+        exactly('1')
+          .and(maybe(exactly('2').and(maybe('3')).and('2')))
+          .and('1')
+      ).grouped()
+    ).grouped()
+
+    const match = 'booboo'.match(createRegExp(pattern))
+
+    if (!match) return expect(match).toBeTruthy()
+    expectTypeOf(match.length).toEqualTypeOf<7>()
+    expectTypeOf(match[0]).toEqualTypeOf<string | undefined>()
+    expectTypeOf(match[1]).toEqualTypeOf<
+      | StringCaptureBy<'((foo\\|\\?)|(?<groupName>bar(baz)?)|(boo){2}|(a{3}|(?:b(?:c\\|d\\?)?)*|1(?:23?2)?1))'>
+      | undefined
+    >()
+    //@ts-expect-error
+    match[1] = 'match result array marked as readonly'
+    let typedVar: string | undefined
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, prefer-const
+    typedVar = match[1] // can be assign to typed variable
+    expectTypeOf(match[2]).toEqualTypeOf<StringCaptureBy<'(foo\\|\\?)'> | undefined>()
+    expectTypeOf(match[2]?.concat(match[3] || '')).toEqualTypeOf<string | undefined>()
+    expectTypeOf(match[3]).toEqualTypeOf<StringCaptureBy<'(?<groupName>bar(baz)?)'> | undefined>()
+    expectTypeOf(match[4]).toEqualTypeOf<StringCaptureBy<'(baz)'> | undefined>()
+    expectTypeOf(match[5]).toEqualTypeOf<StringCaptureBy<'(boo)'> | undefined>()
+    expectTypeOf(match[6]).toEqualTypeOf<
+      StringCaptureBy<'(a{3}|(?:b(?:c\\|d\\?)?)*|1(?:23?2)?1)'> | undefined
+    >()
+    expectTypeOf(match[7]).toEqualTypeOf<never>()
   })
 })

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -59,7 +59,7 @@ describe('inputs', () => {
 
     const nestedInputWithGroup = maybe(exactly('foo').groupedAs('groupName'))
     expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
-      MagicRegExp<'/(?<groupName>foo)?/', 'groupName', never>
+      MagicRegExp<'/(?<groupName>foo)?/', 'groupName', ['(?<groupName>foo)'], never>
     >()
   })
   it('oneOrMore', () => {
@@ -70,7 +70,7 @@ describe('inputs', () => {
 
     const nestedInputWithGroup = oneOrMore(exactly('foo').groupedAs('groupName'))
     expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
-      MagicRegExp<'/(?<groupName>foo)+/', 'groupName', never>
+      MagicRegExp<'/(?<groupName>foo)+/', 'groupName', ['(?<groupName>foo)'], never>
     >()
   })
   it('exactly', () => {
@@ -80,9 +80,14 @@ describe('inputs', () => {
     )
     expectTypeOf(extractRegExp(input)).toEqualTypeOf<'fo\\?\\[a-z\\]\\{2\\}\\/o\\?'>()
 
-    const nestedInputWithGroup = exactly(maybe('foo').and('bar').groupedAs('groupName'))
+    const nestedInputWithGroup = exactly(maybe('foo').grouped().and('bar').groupedAs('groupName'))
     expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
-      MagicRegExp<'/(?<groupName>(?:foo)?bar)/', 'groupName', never>
+      MagicRegExp<
+        '/(?<groupName>(foo)?bar)/',
+        'groupName',
+        ['(?<groupName>(foo)?bar)', '(foo)'],
+        never
+      >
     >()
   })
   it('word', () => {


### PR DESCRIPTION
### Updates
1. Add new generic `CapturedGroupsArr` to `Input` type for tracking captured grouped regex pattern

2. Add `GetCapturedGroupsArr` and `MapToCapturedGroupsArr` utility types
 
3. Update `MagicRegExpMatchArray` type and `match` function type for `String` to return typed array with corresponding type per each index.

4. Add `StringCaptureBy` generic type for a clean way to express what regex pattern each match is captured by.

This PR should also resolve #24

This PR also can be enhanced by resolving all possible match strings as a union type when using generic `StringCaptureBy`,
ex. `StringCaptureBy<'(?<group>foo|da?o)(?:bar|baz)\\k<group>'>` is infer as `'foobazfoo' | 'foobarfoo' | 'dobazdo' | 'dobardo' | 'daobazdao' | 'daobardao'` 🚀 

## Usage
```ts
const pattern = anyOf(
      exactly('foo|?').grouped(),
      exactly('bar').and(maybe('baz').grouped()).groupedAs('groupName'),
      exactly('boo').times(2).grouped(),
      anyOf(
        exactly('a').times(3),
        exactly('b').and(maybe('c|d?')).times.any(),
        exactly('1')
          .and(maybe(exactly('2').and(maybe('3')).and('2')))
          .and('1')
      ).grouped()
    ).grouped()

    const match = 'booboo'.match(createRegExp(pattern))

    if (!match) return expect(match).toBeTruthy()
    expectTypeOf(match.length).toEqualTypeOf<7>()
    expectTypeOf(match[0]).toEqualTypeOf<string | undefined>()
    expectTypeOf(match[1]).toEqualTypeOf<
      | StringCaptureBy<'((foo\\|\\?)|(?<groupName>bar(baz)?)|(boo){2}|(a{3}|(?:b(?:c\\|d\\?)?)*|1(?:23?2)?1))'>
      | undefined
    >()
    //@ts-expect-error
    match[1] = 'match result array marked as readonly'
    let typedVar: string | undefined
    // eslint-disable-next-line @typescript-eslint/no-unused-vars, prefer-const
    typedVar = match[1] // can be assign to typed variable
    expectTypeOf(match[2]).toEqualTypeOf<StringCaptureBy<'(foo\\|\\?)'> | undefined>()
    expectTypeOf(match[2]?.concat(match[3] || '')).toEqualTypeOf<string | undefined>()
    expectTypeOf(match[3]).toEqualTypeOf<StringCaptureBy<'(?<groupName>bar(baz)?)'> | undefined>()
    expectTypeOf(match[4]).toEqualTypeOf<StringCaptureBy<'(baz)'> | undefined>()
    expectTypeOf(match[5]).toEqualTypeOf<StringCaptureBy<'(boo)'> | undefined>()
    expectTypeOf(match[6]).toEqualTypeOf<
      StringCaptureBy<'(a{3}|(?:b(?:c\\|d\\?)?)*|1(?:23?2)?1)'> | undefined
    >()
    expectTypeOf(match[7]).toEqualTypeOf<never>()
```
### Todos
 - [x] add/update types
 - [x] add/update tests