### PR TITLE
fix: update interface `Input` type parameter to contravariant type

### DIFF
--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -24,7 +24,7 @@ export const charNotIn = <T extends string>(chars: T) =>
   createInput(`[^${chars.replace(/[-\\^\]]/g, '\\$&')}]`) as Input<`[^${EscapeChar<T>}]`>
 
 /** This takes an array of inputs and matches any of them */
-export const anyOf = <New extends InputSource<string, string>[]>(...args: New) =>
+export const anyOf = <New extends InputSource[]>(...args: New) =>
   createInput(`(?:${args.map(a => exactly(a)).join('|')})`) as Input<
     `(?:${Join<MapToValues<New>>})`,
     MapToGroups<New>,
@@ -54,23 +54,23 @@ export const not = {
 }
 
 /** Equivalent to `?` - this marks the input as optional */
-export const maybe = <New extends InputSource<string>>(str: New) =>
-  createInput(`${wrap(exactly(str))}?`) as IfUnwrapped<
-    GetValue<New>,
-    Input<`(?:${GetValue<New>})?`, GetGroup<New>, GetCapturedGroupsArr<New>>,
-    Input<`${GetValue<New>}?`, GetGroup<New>, GetCapturedGroupsArr<New>>
+export const maybe = <New extends InputSource>(str: New) =>
+  createInput(`${wrap(exactly(str))}?`) as Input<
+    IfUnwrapped<GetValue<New>, `(?:${GetValue<New>})?`, `${GetValue<New>}?`>,
+    GetGroup<New>,
+    GetCapturedGroupsArr<New>
   >
 
 /** This escapes a string input to match it exactly */
-export const exactly = <New extends InputSource<string>>(
+export const exactly = <New extends InputSource>(
   input: New
 ): Input<GetValue<New>, GetGroup<New>, GetCapturedGroupsArr<New>> =>
   typeof input === 'string' ? (createInput(input.replace(ESCAPE_REPLACE_RE, '\\$&')) as any) : input
 
 /** Equivalent to `+` - this marks the input as repeatable, any number of times but at least once */
-export const oneOrMore = <New extends InputSource<string>>(str: New) =>
-  createInput(`${wrap(exactly(str))}+`) as IfUnwrapped<
-    GetValue<New>,
-    Input<`(?:${GetValue<New>})+`, GetGroup<New>, GetCapturedGroupsArr<New>>,
-    Input<`${GetValue<New>}+`, GetGroup<New>, GetCapturedGroupsArr<New>>
+export const oneOrMore = <New extends InputSource>(str: New) =>
+  createInput(`${wrap(exactly(str))}+`) as Input<
+    IfUnwrapped<GetValue<New>, `(?:${GetValue<New>})+`, `${GetValue<New>}+`>,
+    GetGroup<New>,
+    GetCapturedGroupsArr<New>
   >

--- a/src/core/types/escape.ts
+++ b/src/core/types/escape.ts
@@ -22,7 +22,7 @@ type CharEscapeCharacter = '\\' | '^' | '-' | ']'
 export type EscapeChar<T extends string> = Escape<T, CharEscapeCharacter>
 export type StripEscapes<T extends string> = T extends `${infer A}\\${infer B}` ? `${A}${B}` : T
 
-export type GetValue<T extends InputSource<string>> = T extends string
+export type GetValue<T extends InputSource> = T extends string
   ? Escape<T, ExactEscapeChar>
   : T extends Input<infer R>
   ? R

--- a/src/core/types/sources.ts
+++ b/src/core/types/sources.ts
@@ -1,27 +1,28 @@
 import type { Input } from '../internal'
 import type { GetValue } from './escape'
 
-export type InputSource<S extends string = never, T extends string = never> = S | Input<S, T>
-export type GetGroup<T extends InputSource<string>> = T extends Input<string, infer Group>
-  ? Group
-  : never
+export type InputSource<S extends string = string, T extends string = never> = S | Input<any, T>
+export type GetGroup<T extends InputSource> = T extends Input<any, infer Group> ? Group : never
 export type GetCapturedGroupsArr<
-  T extends InputSource<string>,
+  T extends InputSource,
   MapToUndefined extends boolean = false
-> = T extends Input<string, any, infer CapturedGroupArr>
+> = T extends Input<any, any, infer CapturedGroupArr>
   ? MapToUndefined extends true
     ? { [K in keyof CapturedGroupArr]: undefined }
     : CapturedGroupArr
   : []
-export type MapToValues<T extends InputSource<any, any>[]> = T extends [infer First, ...infer Rest]
-  ? First extends InputSource<string>
+export type MapToValues<T extends InputSource[]> = T extends [
+  infer First,
+  ...infer Rest extends InputSource[]
+]
+  ? First extends InputSource
     ? [GetValue<First>, ...MapToValues<Rest>]
     : []
   : []
 
-export type MapToGroups<T extends InputSource<any, string>[]> = T extends [
+export type MapToGroups<T extends InputSource[]> = T extends [
   infer First,
-  ...infer Rest
+  ...infer Rest extends InputSource[]
 ]
   ? First extends Input<any, infer K>
     ? K | MapToGroups<Rest>
@@ -34,6 +35,6 @@ type Flatten<T extends any[]> = T extends [infer L, ...infer R]
     : [L, ...Flatten<R>]
   : []
 
-export type MapToCapturedGroupsArr<T extends InputSource<any, string>[]> = Flatten<{
+export type MapToCapturedGroupsArr<T extends InputSource[]> = Flatten<{
   [K in keyof T]: T[K] extends Input<any, any, infer C> ? C : string[]
 }>

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -3,8 +3,8 @@ import { StripEscapes } from './types/escape'
 
 export type IfUnwrapped<
   Value extends string,
-  Yes extends Input<string>,
-  No extends Input<string>
+  Yes extends string,
+  No extends string
 > = Value extends `(${string})`
   ? No
   : StripEscapes<Value> extends `${infer A}${infer B}`

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,4 +1,4 @@
 import type { Input } from 'magic-regexp'
 
-export const extractRegExp = <T extends Input<any> = never>(input: T) =>
+export const extractRegExp = <T = never>(input: T) =>
   input as T extends Input<infer RE> ? RE : never


### PR DESCRIPTION
### Updates
1. Add `in` contravariant annotation to type parameter `V` of `Input` type:
```diff
interface Input<
-  V extends string,
+  in V extends string,
  G extends string = never,
  C extends (string | undefined)[] = [] > { ... }
```

2. Refactor `InputSource` to make Input accept any `V` type as it is set as contravariant type:
```diff
- export type InputSource<S extends string = never, T extends string = never> = S | Input<S, T>
+ export type InputSource<S extends string = string, T extends string = never> = S | Input<any, T>
```

3. Update/refactor `IfUnwrapped` type's all parameters to extends `string` instead of `Input` (makes usage more concise)
```diff
- any: () => IfUnwrapped<V, Input<`(?:${V})*`, G>, Input<`${V}*`, G, C>>
+ any: () => Input<IfUnwrapped<V, `(?:${V})*`, `${V}*`>, G, C>
``` 


4. fix ts comments for `and ` and `times` chaining Input helpers

### Note
This PR should resolve the type inferencing issue (using `extractRegExp` helper or directly using `createRegExp`) when implementing new `letter.lowercase` and `letter.uppercase` helper inputs in PR #77 and any future implementations of similar input helpers design to be accessed by `dot notation.



