### PR TITLE
fix: sanitize `createRegExp` return type

### DIFF
--- a/src/core/types/escape.ts
+++ b/src/core/types/escape.ts
@@ -20,7 +20,7 @@ export type EscapeChar<T extends string> = Escape<T, '\\' | '^' | '-' | ']'>
 export type StripEscapes<T extends string> = T extends `${infer A}\\${infer B}` ? `${A}${B}` : T
 
 // prettier-ignore
-type ExactEscapeChar = '.' | '*' | '+' | '?' | '^' | '$' | '{' | '}' | '(' | ')' | '|' | '[' | ']' | '/'
+export type ExactEscapeChar = '.' | '*' | '+' | '?' | '^' | '$' | '{' | '}' | '(' | ')' | '|' | '[' | ']' | '/'
 
 export type GetValue<T extends InputSource> = T extends string
   ? Escape<T, ExactEscapeChar>

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,21 +3,31 @@ import { Input, exactly } from './core/inputs'
 import type { Join } from './core/types/join'
 import type { MagicRegExp, MagicRegExpMatchArray } from './core/types/magic-regexp'
 
-export const createRegExp = <
-  Value extends string,
-  NamedGroups extends string = never,
-  CapturedGroupsArr extends (string | undefined)[] = [],
-  Flags extends Flag[] = never[]
->(
-  raw: Input<Value, NamedGroups, CapturedGroupsArr> | Value,
-  flags?: [...Flags] | string | Set<Flag>
-) =>
-  new RegExp(exactly(raw).toString(), [...(flags || '')].join('')) as MagicRegExp<
-    `/${Value}/${Join<Flags, '', ''>}`,
-    NamedGroups,
-    CapturedGroupsArr,
+import type { Escape, ExactEscapeChar } from './core/types/escape'
+
+export const createRegExp: {
+  /** Create Magic RegExp from Input helper */
+  <
+    Value extends string,
+    NamedGroups extends string = never,
+    CapturedGroupsArr extends (string | undefined)[] = [],
+    Flags extends Flag[] = never[]
+  >(
+    raw: Input<Value, NamedGroups, CapturedGroupsArr>,
+    flags?: [...Flags] | string | Set<Flag>
+  ): MagicRegExp<`/${Value}/${Join<Flags, '', ''>}`, NamedGroups, CapturedGroupsArr, Flags[number]>
+  /** Create Magic RegExp from string, string will be sanitized */
+  <Value extends string, Flags extends Flag[] = never[]>(
+    raw: Value,
+    flags?: [...Flags] | string | Set<Flag>
+  ): MagicRegExp<
+    `/${Escape<Value, ExactEscapeChar>}/${Join<Flags, '', ''>}`,
+    never,
+    [],
     Flags[number]
   >
+} = (raw: any, flags?: any) =>
+  new RegExp(exactly(raw).toString(), [...(flags || '')].join('')) as any
 
 export * from './core/flags'
 export * from './core/inputs'

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -26,7 +26,17 @@ describe('magic-regexp', () => {
   })
   it('collects flag type', () => {
     const re = createRegExp('.', [global, multiline])
-    expectTypeOf(re).toEqualTypeOf<MagicRegExp<'/./gm', never, [], 'g' | 'm'>>()
+    expectTypeOf(re).toEqualTypeOf<MagicRegExp<'/\\./gm', never, [], 'g' | 'm'>>()
+  })
+  it('sanitize string input', () => {
+    const escapeChars = '.*+?^${}()[]/'
+    const re = createRegExp(escapeChars)
+    expect(String(re)).toMatchInlineSnapshot(
+      '"/\\\\.\\\\*\\\\+\\\\?\\\\^\\\\$\\\\{\\\\}\\\\(\\\\)\\\\[\\\\]\\\\//"'
+    )
+    expectTypeOf(re).toEqualTypeOf<
+      MagicRegExp<'/\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\[\\]\\//', never, []>
+    >()
   })
 })
 


### PR DESCRIPTION
## Fix

fix #160 

## Updates
1. Update `createRegExp` to type-Level function overloading, so the return type string is sanitized if the raw input argument is string type.
2. Update/Add relevant tests