### PR TITLE
docs: add missing imports in examples.md

### DIFF
--- a/docs/content/2.getting-started/3.examples.md
+++ b/docs/content/2.getting-started/3.examples.md
@@ -5,7 +5,7 @@ title: Examples
 ### Quick-and-dirty semver
 
 ```js
-import { createRegExp, exactly, oneOrMore, digit } from 'magic-regexp'
+import { createRegExp, exactly, oneOrMore, digit, char } from 'magic-regexp'
 
 createRegExp(
   oneOrMore(digit)
@@ -21,7 +21,7 @@ createRegExp(
 
 ```js
 import assert from 'node:assert'
-import { createRegExp, word, char, oneOrMore } from 'magic-regexp'
+import { createRegExp, wordChar, char, oneOrMore } from 'magic-regexp'
 
 const TENET_RE = createRegExp(
   wordChar


### PR DESCRIPTION
Hi, I noticed there are two missing imports in the Examples page
- `char` in the 1st example
- `wordChar` in the 2nd example