### PR TITLE
feat: add `not.word` helper input

### DIFF
--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -46,7 +46,7 @@ export const linefeed = createInput('\\n')
 export const carriageReturn = createInput('\\r')
 
 export const not = {
-  word: createInput('\\b\\W+\\b'),
+  word: createInput('\\W+'),
   wordChar: createInput('\\W'),
   wordBoundary: createInput('\\B'),
   digit: createInput('\\D'),

--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -46,6 +46,7 @@ export const linefeed = createInput('\\n')
 export const carriageReturn = createInput('\\r')
 
 export const not = {
+  word: createInput('\\b\\W+\\b'),
   wordChar: createInput('\\W'),
   wordBoundary: createInput('\\B'),
   digit: createInput('\\D'),

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -146,8 +146,8 @@ describe('inputs', () => {
     expectTypeOf(extractRegExp(input)).toEqualTypeOf<'\\r'>()
   })
   it('not', () => {
-    expect(not.word.toString()).toMatchInlineSnapshot('"\\\\b\\\\W+\\\\b"')
-    expectTypeOf(extractRegExp(not.word)).toEqualTypeOf<'\\b\\W+\\b'>()
+    expect(not.word.toString()).toMatchInlineSnapshot('"\\\\W+"')
+    expectTypeOf(extractRegExp(not.word)).toEqualTypeOf<'\\W+'>()
     expect(not.wordChar.toString()).toMatchInlineSnapshot('"\\\\W"')
     expectTypeOf(extractRegExp(not.wordChar)).toEqualTypeOf<'\\W'>()
     expect(not.wordBoundary.toString()).toMatchInlineSnapshot('"\\\\B"')

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -146,6 +146,8 @@ describe('inputs', () => {
     expectTypeOf(extractRegExp(input)).toEqualTypeOf<'\\r'>()
   })
   it('not', () => {
+    expect(not.word.toString()).toMatchInlineSnapshot('"\\\\b\\\\W+\\\\b"')
+    expectTypeOf(extractRegExp(not.word)).toEqualTypeOf<'\\b\\W+\\b'>()
     expect(not.wordChar.toString()).toMatchInlineSnapshot('"\\\\W"')
     expectTypeOf(extractRegExp(not.wordChar)).toEqualTypeOf<'\\W'>()
     expect(not.wordBoundary.toString()).toMatchInlineSnapshot('"\\\\B"')


### PR DESCRIPTION
## Update
added missing `not.word` helper input as RegExp `\W+`

## Usage
```ts
    const result = 'foo-bar'.match(createRegExp(not.word))
    // result[0] === '-'
```

## Resolve
resolve #232

 - [x] add/update tests
 - [x] update docs (added at initial commit)