### PR TITLE
feat: variadic input helpers

### DIFF
--- a/docs/content/2.getting-started/2.usage.md
+++ b/docs/content/2.getting-started/2.usage.md
@@ -15,7 +15,7 @@ console.log(regExp)
 
 Every pattern you create with the library should be wrapped in `createRegExp`, which enables the build-time transform.
 
-The first argument is either a string to match exactly, or an input pattern built up using helpers from `magic-regexp`. It also takes a second argument, which is an array of flags or flags string.
+`createRegExp` accepts arbitrary number of arguments of type `string`, or `Input` that are built up using helpers from `magic-regexp`, and an optional final argument of an array of flags or flags string. It creates a `MagicRegExp`, which has all the patterns from the inputs concatenated.
 
 ```js
 import { createRegExp, global, multiline, exactly } from 'magic-regexp'
@@ -25,6 +25,16 @@ createRegExp(exactly('foo').or('bar'))
 createRegExp('string-to-match', [global, multiline])
 // you can also pass flags directly as strings or Sets
 createRegExp('string-to-match', ['g', 'm'])
+
+// or pass in multiple `string` and `input patterns`,
+// all inputs will be concatenated to one RegExp pattern
+createRegExp(
+    'foo',
+    maybe('bar').groupedAs('g1'),
+    'baz',
+    [global, multiline]
+) 
+// equivalent to /foo(?<g1>(?:bar)?)baz/gm
 ```
 
 ::alert
@@ -38,12 +48,16 @@ There are a range of helpers that can be used to activate pattern matching, and 
 |                                                                                                                     |                                                                                                                                                                     |
 | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `charIn`, `charNotIn`                                                                                               | this matches or doesn't match any character in the string provided.                                                                                                 |
-| `anyOf`                                                                                                             | this takes an array of inputs and matches any of them.                                                                                                              |
+| `anyOf`                                                                                                             | this takes a variable number of inputs and matches any of them.                                                                                                              |
 | `char`, `word`, `wordChar`, `wordBoundary`, `digit`, `whitespace`, `letter`, `letter.lowercase`, `letter.uppercase`, `tab`, `linefeed` and `carriageReturn` | these are helpers for specific RegExp characters.                                                                                                                   |
 | `not`                                                                                                               | this can prefix `word`, `wordChar`, `wordBoundary`, `digit`, `whitespace`, `letter`, `letter.lowercase`, `letter.uppercase`, `tab`, `linefeed` or `carriageReturn`. For example `createRegExp(not.letter)`. |
-| `maybe`                                                                                                             | equivalent to `?` - this marks the input as optional.                                                                                                               |
-| `oneOrMore`                                                                                                         | Equivalent to `+` - this marks the input as repeatable, any number of times but at least once.                                                                      |
-| `exactly`                                                                                                           | This escapes a string input to match it exactly.                                                                                                                    |
+| `maybe`                                                                                                             | equivalent to `?` - this takes a variable number of inputs and marks them as optional.                                                                                                               |
+| `oneOrMore`                                                                                                         | Equivalent to `+` - this takes a variable number of inputs and marks them as repeatable, any number of times but at least once.                                                                      |
+| `exactly`                                                                                                           | This takes a variable number of inputs and concatenate their patterns, and escapes string inputs to match it exactly.                                                                                                                    |
+
+::alert
+All helpers that takes `string` and `Input` are variadic functions, so you can pass in one or multiple arguments of `string` or `Input` to them and they will be concatenated to one pattern. for example,s `exactly('foo', maybe('bar'))` is equivalent to `exactly('foo').and(maybe('bar'))`.
+::
 
 ## Chaining inputs
 
@@ -51,9 +65,9 @@ All of the helpers above return an object of type `Input` that can be chained wi
 
 |                                               |                                                                                                                                                                                                                                                                                                          |
 | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `and`                                         | this adds a new pattern to the current input, or you can use `and.referenceTo(groupName)` to adds a new pattern referencing to a named group.                                                                                                                                                            |
-| `or`                                          | this provides an alternative to the current input.                                                                                                                                                                                                                                                       |
-| `after`, `before`, `notAfter` and `notBefore` | these activate positive/negative lookahead/lookbehinds. Make sure to check [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility) as not all browsers support lookbehinds (notably Safari).                                    |
+| `and`                                         | this takes a variable number of inputs and adds them as new pattern to the current input, or you can use `and.referenceTo(groupName)` to adds a new pattern referencing to a named group.                                                                                                                                                            |
+| `or`                                          | this takes a variable number of inputs and provides as an alternative to the current input.                                                                                                                                                                                                                                                       |
+| `after`, `before`, `notAfter` and `notBefore` | these takes a variable number of inputs and activate positive/negative lookahead/lookbehinds. Make sure to check [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility) as not all browsers support lookbehinds (notably Safari).                                    |
 | `times`                                       | this is a function you can call directly to repeat the previous pattern an exact number of times, or you can use `times.between(min, max)` to specify a range, `times.atLeast(x)` to indicate it must repeat at least x times, `times.atMost(x)` to indicate it must repeat at most x times or `times.any()` to indicate it can repeat any number of times, _including none_. |
 | `optionally`                                  | this is a function you can call to mark the current input as optional.                                                                                                                                                                                                                                   |
 | `as`                                          | alias for `groupedAs`                                                                                                                                                                                                                                                                                    |

--- a/docs/content/2.getting-started/2.usage.md
+++ b/docs/content/2.getting-started/2.usage.md
@@ -15,7 +15,7 @@ console.log(regExp)
 
 Every pattern you create with the library should be wrapped in `createRegExp`, which enables the build-time transform.
 
-`createRegExp` accepts arbitrary number of arguments of type `string`, or `Input` that are built up using helpers from `magic-regexp`, and an optional final argument of an array of flags or flags string. It creates a `MagicRegExp`, which has all the patterns from the inputs concatenated.
+`createRegExp` accepts an arbitrary number of arguments of type `string` or `Input` (built up using helpers from `magic-regexp`), and an optional final argument of an array of flags or a flags string. It creates a `MagicRegExp`, which concatenates all the patterns from the arguments that were passed in.
 
 ```js
 import { createRegExp, global, multiline, exactly } from 'magic-regexp'

--- a/docs/content/2.getting-started/2.usage.md
+++ b/docs/content/2.getting-started/2.usage.md
@@ -29,10 +29,10 @@ createRegExp('string-to-match', ['g', 'm'])
 // or pass in multiple `string` and `input patterns`,
 // all inputs will be concatenated to one RegExp pattern
 createRegExp(
-    'foo',
-    maybe('bar').groupedAs('g1'),
-    'baz',
-    [global, multiline]
+  'foo',
+  maybe('bar').groupedAs('g1'),
+  'baz',
+  [global, multiline]
 ) 
 // equivalent to /foo(?<g1>(?:bar)?)baz/gm
 ```

--- a/docs/content/2.getting-started/3.examples.md
+++ b/docs/content/2.getting-started/3.examples.md
@@ -5,14 +5,13 @@ title: Examples
 ### Quick-and-dirty semver
 
 ```js
-import { createRegExp, exactly, oneOrMore, digit, char } from 'magic-regexp'
+import { createRegExp, exactly, maybe, oneOrMore, digit, char } from 'magic-regexp'
 
 createRegExp(
-  oneOrMore(digit)
-    .groupedAs('major')
-    .and('.')
-    .and(oneOrMore(digit).groupedAs('minor'))
-    .and(exactly('.').and(oneOrMore(char).groupedAs('patch')).optionally())
+  oneOrMore(digit).groupedAs('major'),
+  '.',
+  oneOrMore(digit).groupedAs('minor'),
+  maybe('.', oneOrMore(char).groupedAs('patch'))
 )
 // /(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>.+))?/
 ```

--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -16,7 +16,11 @@ export const charIn = <T extends string>(chars: T) =>
 export const charNotIn = <T extends string>(chars: T) =>
   createInput(`[^${chars.replace(/[-\\^\]]/g, '\\$&')}]`) as Input<`[^${EscapeChar<T>}]`>
 
-/** This takes an array of inputs and matches any of them */
+/** This takes a variable number of inputs and matches any of them
+ * @example
+ * anyOf('foo', maybe('bar'), 'baz') // => /(?:foo|(?:bar)?|baz)/
+ * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+ */
 export const anyOf = <Inputs extends InputSource[]>(
   ...inputs: Inputs
 ): Input<`(?:${Join<MapToValues<Inputs>>})`, MapToGroups<Inputs>, MapToCapturedGroupsArr<Inputs>> =>
@@ -50,7 +54,11 @@ export const not = {
   carriageReturn: createInput('[^\\r]'),
 }
 
-/** Equivalent to `?` - this marks the input as optional */
+/** Equivalent to `?` - takes a variable number of inputs and marks them as optional
+ * @example
+ * maybe('foo', excatly('ba?r')) // => /(?:fooba\?r)?/
+ * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+ */
 export const maybe = <
   Inputs extends InputSource[],
   Value extends string = Join<MapToValues<Inputs>, '', ''>
@@ -62,7 +70,11 @@ export const maybe = <
   MapToCapturedGroupsArr<Inputs>
 > => createInput(`${wrap(exactly(...inputs))}?`)
 
-/** This escapes a string input to match it exactly */
+/** This takes a variable number of inputs and concatenate their patterns, and escapes string inputs to match it exactly
+ * @example
+ * exactly('fo?o', maybe('bar')) // => /fo\?o(?:bar)?/
+ * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+ */
 export const exactly = <Inputs extends InputSource[]>(
   ...inputs: Inputs
 ): Input<Join<MapToValues<Inputs>, '', ''>, MapToGroups<Inputs>, MapToCapturedGroupsArr<Inputs>> =>
@@ -72,7 +84,11 @@ export const exactly = <Inputs extends InputSource[]>(
       .join('')
   )
 
-/** Equivalent to `+` - this marks the input as repeatable, any number of times but at least once */
+/** Equivalent to `+` - this takes a variable number of inputs and marks them as repeatable, any number of times but at least once
+ * @example
+ * oneOrMore('foo', maybe('bar')) // => /(?:foo(?:bar)?)+/
+ * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+ */
 export const oneOrMore = <
   Inputs extends InputSource[],
   Value extends string = Join<MapToValues<Inputs>, '', ''>

--- a/src/core/internal.ts
+++ b/src/core/internal.ts
@@ -11,7 +11,11 @@ export interface Input<
   G extends string = never,
   C extends (string | undefined)[] = []
 > {
-  /** this adds a new pattern to the current input */
+  /** this  takes a variable number of inputs and adds them as new pattern to the current input, or you can use `and.referenceTo(groupName)` to adds a new pattern referencing to a named group
+   * @example
+   * exactly('foo').and('bar', maybe('baz')) // => /foobar(?:baz)?/
+   * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+   */
   and: {
     <I extends InputSource[], CG extends any[] = MapToCapturedGroupsArr<I>>(...inputs: I): Input<
       `${V}${Join<MapToValues<I>, '', ''>}`,
@@ -21,23 +25,43 @@ export interface Input<
     /** this adds a new pattern to the current input, with the pattern reference to a named group. */
     referenceTo: <N extends G>(groupName: N) => Input<`${V}\\k<${N}>`, G, C>
   }
-  /** this provides an alternative to the current input */
+  /** this takes a variable number of inputs and provides as an alternative to the current input
+   * @example
+   * exactly('foo').or('bar', maybe('baz')) // => /foo|bar(?:baz)?/
+   * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+   */
   or: <I extends InputSource[], CG extends any[] = MapToCapturedGroupsArr<I>>(
     ...inputs: I
   ) => Input<`(?:${V}|${Join<MapToValues<I>, '', ''>})`, G | MapToGroups<I>, [...C, ...CG]>
-  /** this is a positive lookbehind. Make sure to check [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility) as not all browsers support lookbehinds (notably Safari) */
+  /** this takes a variable number of inputs and activate a positive lookbehind. Make sure to check [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility) as not all browsers support lookbehinds (notably Safari)
+   * @example
+   * exactly('foo').after('bar', maybe('baz')) // => /(?<=bar(?:baz)?)foo/
+   * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+   */
   after: <I extends InputSource[], CG extends any[] = MapToCapturedGroupsArr<I>>(
     ...inputs: I
   ) => Input<`(?<=${Join<MapToValues<I>, '', ''>})${V}`, G | MapToGroups<I>, [...CG, ...C]>
-  /** this is a positive lookahead */
+  /** this takes a variable number of inputs and activate a positive lookahead
+   * @example
+   * exactly('foo').before('bar', maybe('baz')) // => /foo(?=bar(?:baz)?)/
+   * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+   */
   before: <I extends InputSource[], CG extends any[] = MapToCapturedGroupsArr<I>>(
     ...inputs: I
   ) => Input<`${V}(?=${Join<MapToValues<I>, '', ''>})`, G, [...C, ...CG]>
-  /** these is a negative lookbehind. Make sure to check [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility) as not all browsers support lookbehinds (notably Safari) */
+  /** these takes a variable number of inputs and activate a negative lookbehind. Make sure to check [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility) as not all browsers support lookbehinds (notably Safari)
+   * @example
+   * exactly('foo').notAfter('bar', maybe('baz')) // => /(?<!bar(?:baz)?)foo/
+   * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+   */
   notAfter: <I extends InputSource[], CG extends any[] = MapToCapturedGroupsArr<I, true>>(
     ...inputs: I
   ) => Input<`(?<!${Join<MapToValues<I>, '', ''>})${V}`, G, [...CG, ...C]>
-  /** this is a negative lookahead */
+  /** this takes a variable number of inputs and activate a negative lookahead
+   * @example
+   * exactly('foo').notBefore('bar', maybe('baz')) // => /foo(?!bar(?:baz)?)/
+   * @argument inputs - arbitrary number of `string` or `Input`, where `string` will be escaped
+   */
   notBefore: <I extends InputSource[], CG extends any[] = MapToCapturedGroupsArr<I, true>>(
     ...inputs: I
   ) => Input<`${V}(?!${Join<MapToValues<I>, '', ''>})`, G, [...C, ...CG]>

--- a/src/core/types/join.ts
+++ b/src/core/types/join.ts
@@ -7,3 +7,15 @@ export type Join<
     ? `${Prefix}${F}${R extends string[] ? Join<R, Joiner, Joiner> : ''}`
     : ''
   : ''
+
+type UnionToIntersection<Union> = (Union extends Union ? (a: Union) => any : never) extends (
+  a: infer I
+) => any
+  ? I
+  : never
+
+export type UnionToTuple<Union, Tuple extends any[] = []> = UnionToIntersection<
+  Union extends any ? () => Union : never
+> extends () => infer Item
+  ? UnionToTuple<Exclude<Union, Item>, [...Tuple, Item]>
+  : Tuple

--- a/src/core/types/sources.ts
+++ b/src/core/types/sources.ts
@@ -2,15 +2,7 @@ import type { Input } from '../internal'
 import type { GetValue } from './escape'
 
 export type InputSource<S extends string = string, T extends string = never> = S | Input<any, T>
-export type GetGroup<T extends InputSource> = T extends Input<any, infer Group> ? Group : never
-export type GetCapturedGroupsArr<
-  T extends InputSource,
-  MapToUndefined extends boolean = false
-> = T extends Input<any, any, infer CapturedGroupArr>
-  ? MapToUndefined extends true
-    ? { [K in keyof CapturedGroupArr]: undefined }
-    : CapturedGroupArr
-  : []
+
 export type MapToValues<T extends InputSource[]> = T extends [
   infer First,
   ...infer Rest extends InputSource[]
@@ -29,12 +21,27 @@ export type MapToGroups<T extends InputSource[]> = T extends [
     : MapToGroups<Rest>
   : never
 
-type Flatten<T extends any[]> = T extends [infer L, ...infer R]
-  ? L extends any[]
-    ? [...Flatten<L>, ...Flatten<R>]
-    : [L, ...Flatten<R>]
-  : []
-
-export type MapToCapturedGroupsArr<T extends InputSource[]> = Flatten<{
-  [K in keyof T]: T[K] extends Input<any, any, infer C> ? C : string[]
-}>
+export type MapToCapturedGroupsArr<
+  Inputs extends any[],
+  MapToUndefined extends boolean = false,
+  CapturedGroupsArr extends any[] = [],
+  Count extends any[] = []
+> = Count['length'] extends Inputs['length']
+  ? CapturedGroupsArr
+  : Inputs[Count['length']] extends Input<any, any, infer CaptureGroups>
+  ? [CaptureGroups] extends [never]
+    ? MapToCapturedGroupsArr<Inputs, MapToUndefined, [...CapturedGroupsArr], [...Count, '']>
+    : MapToUndefined extends true
+    ? MapToCapturedGroupsArr<
+        Inputs,
+        MapToUndefined,
+        [...CapturedGroupsArr, undefined],
+        [...Count, '']
+      >
+    : MapToCapturedGroupsArr<
+        Inputs,
+        MapToUndefined,
+        [...CapturedGroupsArr, ...CaptureGroups],
+        [...Count, '']
+      >
+  : MapToCapturedGroupsArr<Inputs, MapToUndefined, [...CapturedGroupsArr], [...Count, '']>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -27,8 +27,11 @@ describe('magic-regexp', () => {
     expectTypeOf(regExp).not.toEqualTypeOf(RegExp)
   })
   it('collects flag type', () => {
-    const re = createRegExp('.', [global, multiline])
-    expectTypeOf(re).toEqualTypeOf<MagicRegExp<'/\\./gm', never, [], 'g' | 'm'>>()
+    const re_array_flag = createRegExp('.', [global, multiline])
+    expectTypeOf(re_array_flag).toEqualTypeOf<MagicRegExp<'/\\./gm', never, [], 'g' | 'm'>>()
+
+    const re_set_flag = createRegExp('.', new Set([global] as const))
+    expectTypeOf(re_set_flag).toEqualTypeOf<MagicRegExp<'/\\./g', never, [], 'g'>>()
   })
   it('sanitize string input', () => {
     const escapeChars = '.*+?^${}()[]/'

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -61,6 +61,13 @@ describe('inputs', () => {
     expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
       MagicRegExp<'/(?<groupName>foo)?/', 'groupName', ['(?<groupName>foo)'], never>
     >()
+
+    const multi = maybe('foo', input.groupedAs('groupName'), 'bar')
+    const regexp2 = new RegExp(multi as any)
+    expect(regexp2).toMatchInlineSnapshot(
+      '/\\(\\?:foo\\(\\?<groupName>\\(\\?:foo\\)\\?\\)bar\\)\\?/'
+    )
+    expectTypeOf(extractRegExp(multi)).toEqualTypeOf<'(?:foo(?<groupName>(?:foo)?)bar)?'>()
   })
   it('oneOrMore', () => {
     const input = oneOrMore('foo')
@@ -72,6 +79,13 @@ describe('inputs', () => {
     expectTypeOf(createRegExp(nestedInputWithGroup)).toEqualTypeOf<
       MagicRegExp<'/(?<groupName>foo)+/', 'groupName', ['(?<groupName>foo)'], never>
     >()
+
+    const multi = oneOrMore('foo', input.groupedAs('groupName'), 'bar')
+    const regexp2 = new RegExp(multi as any)
+    expect(regexp2).toMatchInlineSnapshot(
+      '/\\(\\?:foo\\(\\?<groupName>\\(\\?:foo\\)\\+\\)bar\\)\\+/'
+    )
+    expectTypeOf(extractRegExp(multi)).toEqualTypeOf<'(?:foo(?<groupName>(?:foo)+)bar)+'>()
   })
   it('exactly', () => {
     const input = exactly('fo?[a-z]{2}/o?')
@@ -89,6 +103,15 @@ describe('inputs', () => {
         never
       >
     >()
+
+    const multi = exactly('foo', input.groupedAs('groupName'), 'bar')
+    const regexp2 = new RegExp(multi as any)
+    expect(regexp2).toMatchInlineSnapshot(
+      '/foo\\(\\?<groupName>fo\\\\\\?\\\\\\[a-z\\\\\\]\\\\\\{2\\\\\\}\\\\/o\\\\\\?\\)bar/'
+    )
+    expectTypeOf(
+      extractRegExp(multi)
+    ).toEqualTypeOf<'foo(?<groupName>fo\\?\\[a-z\\]\\{2\\}\\/o\\?)bar'>()
   })
   it('word', () => {
     const input = word
@@ -193,6 +216,11 @@ describe('chained inputs', () => {
     const regexp = new RegExp(val as any)
     expect(regexp).toMatchInlineSnapshot('/\\\\\\?test\\\\\\.js/')
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?test\\.js'>()
+
+    const multi = multichar.and('foo', input.groupedAs('groupName'), 'bar')
+    const regexp2 = new RegExp(multi as any)
+    expect(regexp2).toMatchInlineSnapshot('/abfoo\\(\\?<groupName>\\\\\\?\\)bar/')
+    expectTypeOf(extractRegExp(multi)).toEqualTypeOf<'abfoo(?<groupName>\\?)bar'>()
   })
   it('and.referenceTo', () => {
     const val = input.groupedAs('namedGroup').and(exactly('any')).and.referenceTo('namedGroup')
@@ -208,30 +236,59 @@ describe('chained inputs', () => {
     expect(regexp.test(test)).toBeTruthy()
     expect(regexp.exec(test)?.[1]).toBeUndefined()
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'(?:\\?|test\\.js)'>()
+
+    const multi = multichar.or('foo', input.groupedAs('groupName'), exactly('bar').or(test))
+    const regexp2 = new RegExp(multi as any)
+    expect(regexp2).toMatchInlineSnapshot(
+      '/\\(\\?:ab\\|foo\\(\\?<groupName>\\\\\\?\\)\\(\\?:bar\\|test\\\\\\.js\\)\\)/'
+    )
+    expectTypeOf(
+      extractRegExp(multi)
+    ).toEqualTypeOf<'(?:ab|foo(?<groupName>\\?)(?:bar|test\\.js))'>()
   })
   it('after', () => {
     const val = input.after('test.js')
     const regexp = new RegExp(val as any)
     expect(regexp).toMatchInlineSnapshot('/\\(\\?<=test\\\\\\.js\\)\\\\\\?/')
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'(?<=test\\.js)\\?'>()
+
+    const multi = multichar.after('foo', input.groupedAs('groupName'), 'bar')
+    const regexp2 = new RegExp(multi as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\(\\?<=foo\\(\\?<groupName>\\\\\\?\\)bar\\)ab/')
+    expectTypeOf(extractRegExp(multi)).toEqualTypeOf<'(?<=foo(?<groupName>\\?)bar)ab'>()
   })
   it('before', () => {
     const val = input.before('test.js')
     const regexp = new RegExp(val as any)
     expect(regexp).toMatchInlineSnapshot('/\\\\\\?\\(\\?=test\\\\\\.js\\)/')
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?(?=test\\.js)'>()
+
+    const multi = multichar.before('foo', input.groupedAs('groupName'), 'bar')
+    const regexp2 = new RegExp(multi as any)
+    expect(regexp2).toMatchInlineSnapshot('/ab\\(\\?=foo\\(\\?<groupName>\\\\\\?\\)bar\\)/')
+    expectTypeOf(extractRegExp(multi)).toEqualTypeOf<'ab(?=foo(?<groupName>\\?)bar)'>()
   })
   it('notAfter', () => {
     const val = input.notAfter('test.js')
     const regexp = new RegExp(val as any)
     expect(regexp).toMatchInlineSnapshot('/\\(\\?<!test\\\\\\.js\\)\\\\\\?/')
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'(?<!test\\.js)\\?'>()
+
+    const multi = multichar.notAfter('foo', input.groupedAs('groupName'), 'bar')
+    const regexp2 = new RegExp(multi as any)
+    expect(regexp2).toMatchInlineSnapshot('/\\(\\?<!foo\\(\\?<groupName>\\\\\\?\\)bar\\)ab/')
+    expectTypeOf(extractRegExp(multi)).toEqualTypeOf<'(?<!foo(?<groupName>\\?)bar)ab'>()
   })
   it('notBefore', () => {
     const val = input.notBefore('test.js')
     const regexp = new RegExp(val as any)
     expect(regexp).toMatchInlineSnapshot('/\\\\\\?\\(\\?!test\\\\\\.js\\)/')
     expectTypeOf(extractRegExp(val)).toEqualTypeOf<'\\?(?!test\\.js)'>()
+
+    const multi = multichar.notBefore('foo', input.groupedAs('groupName'), 'bar')
+    const regexp2 = new RegExp(multi as any)
+    expect(regexp2).toMatchInlineSnapshot('/ab\\(\\?!foo\\(\\?<groupName>\\\\\\?\\)bar\\)/')
+    expectTypeOf(extractRegExp(multi)).toEqualTypeOf<'ab(?!foo(?<groupName>\\?)bar)'>()
   })
   it('times', () => {
     const val = input.times(500)


### PR DESCRIPTION
## Update & Proposal
Update input helpers to take variadic arguments, eg: `exactly('foo', maybe('bar'), 'baz'...)`, enabling a more concise syntax and improving the overall readability of the code.

Currently, the input helpers take only one argument of either type `string` or another `Input`. To concatenate different RegExp patterns, users need to use the `.and()` chaining helper repeatedly. This approach is very descriptive but can also make the code verbose and difficult to read when dealing with multiple input helpers in more complex scenario.

To improve the syntax and readability, I want to propose an update to all input helpers to variadic function that take one or more `string` or `Input` as arguments.
And this update will maintain backward compatibility, as the new helpers still accept a single argument of type `string` or `Input`, and still can chain using `.and()`. However, users will also have the option to pass multiple arguments to the functions, which will be concatenated accordingly.

please let me know your suggestion, feedback, and input.

## Updated inputs
- [x] `createRegExp` (last array arg as flags)
- [x] `maybe`
- [x] `exactly`
- [x] `oneOrMore`
- [x] `.and`
- [x] `.or`
- [x] `.after`
- [x] `.before`
- [x] `.notAfter`
- [x] `.notBefore`

## Example
original `semver` example
```ts
const regExp = createRegExp(
  oneOrMore(digit)
    .groupedAs('major')
    .and('.')
    .and(oneOrMore(digit).groupedAs('minor'))
    .and(exactly('.').and(oneOrMore(char).groupedAs('patch')).optionally())
)
```
with this update, can be simplified to:
```ts
  const regExp2 = createRegExp(
      oneOrMore(digit).groupedAs('major'),
      '.',
      oneOrMore(digit).groupedAs('minor'),
      maybe('.', oneOrMore(char).groupedAs('patch'))
    )
```

## Related issues
#237 

 - [x] add/update tests
 - [x] update docs
 - [x] update jsdoc comments