### PR TITLE
fix: fix `Input` generic contravariant error with TS 5+

### DIFF
--- a/src/core/internal.ts
+++ b/src/core/internal.ts
@@ -7,7 +7,7 @@ const GROUPED_AS_REPLACE_RE = /^(?:\(\?:(.+)\)|(\(?.+\)?))$/
 const GROUPED_REPLACE_RE = /^(?:\(\?:(.+)\)([?+*]|{[\d,]+})?|(.+))$/
 
 export interface Input<
-  in V extends string,
+  V extends string,
   G extends string = never,
   C extends (string | undefined)[] = []
 > {
@@ -67,22 +67,34 @@ export interface Input<
   ) => Input<`${V}(?!${Join<MapToValues<I>, '', ''>})`, G, [...C, ...CG]>
   /** repeat the previous pattern an exact number of times */
   times: {
-    <N extends number>(number: N): Input<IfUnwrapped<V, `(?:${V}){${N}}`, `${V}{${N}}`>, G, C>
+    <N extends number, NV extends string = IfUnwrapped<V, `(?:${V}){${N}}`, `${V}{${N}}`>>(
+      number: N
+    ): Input<NV, G, C>
     /** specify that the expression can repeat any number of times, _including none_ */
-    any: () => Input<IfUnwrapped<V, `(?:${V})*`, `${V}*`>, G, C>
+    any: <NV extends string = IfUnwrapped<V, `(?:${V})*`, `${V}*`>>() => Input<NV, G, C>
     /** specify that the expression must occur at least `N` times */
-    atLeast: <N extends number>(
+    atLeast: <
+      N extends number,
+      NV extends string = IfUnwrapped<V, `(?:${V}){${N},}`, `${V}{${N},}`>
+    >(
       number: N
-    ) => Input<IfUnwrapped<V, `(?:${V}){${N},}`, `${V}{${N},}`>, G, C>
+    ) => Input<NV, G, C>
     /** specify that the expression must occur at most `N` times */
-    atMost: <N extends number>(
+    atMost: <
+      N extends number,
+      NV extends string = IfUnwrapped<V, `(?:${V}){0,${N}}`, `${V}{0,${N}}`>
+    >(
       number: N
-    ) => Input<IfUnwrapped<V, `(?:${V}){0,${N}}`, `${V}{0,${N}}`>, G, C>
+    ) => Input<NV, G, C>
     /** specify a range of times to repeat the previous pattern */
-    between: <Min extends number, Max extends number>(
+    between: <
+      Min extends number,
+      Max extends number,
+      NV extends string = IfUnwrapped<V, `(?:${V}){${Min},${Max}}`, `${V}{${Min},${Max}}`>
+    >(
       min: Min,
       max: Max
-    ) => Input<IfUnwrapped<V, `(?:${V}){${Min},${Max}}`, `${V}{${Min},${Max}}`>, G, C>
+    ) => Input<NV, G, C>
   }
   /** this defines the entire input so far as a named capture group. You will get type safety when using the resulting RegExp with `String.match()`. Alias for `groupedAs` */
   as: <K extends string>(
@@ -112,7 +124,8 @@ export interface Input<
     lineEnd: () => Input<`${V}$`, G, C>
   }
   /** this allows you to mark the input so far as optional */
-  optionally: () => Input<IfUnwrapped<V, `(?:${V})?`, `${V}?`>, G, C>
+  optionally: <NV extends string = IfUnwrapped<V, `(?:${V})?`, `${V}?`>>() => Input<NV, G, C>
+
   toString: () => string
 }
 


### PR DESCRIPTION
## Note
When resolving type inferencing issue (using `extractRegExp` helper or directly using `createRegExp`) when implementing new `letter.lowercase` and `letter.uppercase` helper inputs in PR #77  we update the generic argument `V` of interface `Input` to a contravariant generic arg in PR #79, which in the newest TypeScript 5.0.2 and above cause type error:
```
Type 'Input<super-V, G, C>' is not assignable to type 'Input<sub-V, G, C>' as implied by variance annotation.Type 'Input<super-V, G, C>' is not assignable to type 'Input<sub-V, G, C>' as implied by variance annotation.
```
to resolve this issue and #77, we can actually remove the variance annotation and change the position of where the "new value" of `V` (the built-up RegExp pattern string) of `Input` interface, this prevent the wrong inferencing of `V` seen in #77. 

## Updates
1. Remove `in` [contravariant annotation](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#optional-variance-annotations-for-type-parameters) to type parameter `V` of `Input` interface:
```diff
interface Input<
-  in V extends string,
+  V extends string,
  G extends string = never,
  C extends (string | undefined)[] = [] > { ... }
```

2. Add `NV` generic arguments to `Input` chain functions and resolve the new RegExp pattern string literal type as arg default, for example:
```diff
 between: <
      Min extends number,
      Max extends number,
+    NV extends string = IfUnwrapped<V, `(?:${V}){${Min},${Max}}`, `${V}{${Min},${Max}}`>
    >(
      min: Min,
      max: Max
      ) => 
    Input<
-       IfUnwrapped<V, `(?:${V}){${Min},${Max}}`, `${V}{${Min},${Max}}`>, G, C>,
+       NV,
        G,
        C
    >
```

## Related issues
#77 