### PR TITLE
chore: prefer `nuxt` over `nuxi`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "unbuild",
     "dev": "vitest dev",
-    "docs:generate": "nuxi generate docs",
+    "docs:generate": "nuxt generate docs",
     "lint": "eslint .",
     "prepare": "npx simple-git-hooks && pnpm build",
     "prepublishOnly": "pnpm lint && pnpm test",


### PR DESCRIPTION

this follows up on https://github.com/nuxt/nuxt/pull/32237 to use `nuxt` command consistently now that we no longer need compatibility with nuxt 2.