### PR TITLE
fix(wrap): correctly detect single balanced group (#549)

### DIFF
--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -11,9 +11,49 @@ export type IfUnwrapped<Value extends string, Yes, No> = Value extends `(${strin
         : Yes
     : never
 
-const NO_WRAP_RE = /^(?:\(.*\)|\\?.)$/
+const SINGLE_CHAR_RE = /^\\?.$/
+
+/**
+ * Returns true when the string is a single balanced parenthesised group
+ * that spans from the first `(` to the last `)` — e.g. `(?:foo)`,
+ * `(?<name>foo)`, or `(foo(bar))`. Returns false for concatenations such
+ * as `(?:a)?(?<b>\d+)` which happen to start with `(` and end with `)`.
+ */
+function isSingleGroup(v: string) {
+  if (v.length < 2 || v[0] !== '(' || v[v.length - 1] !== ')')
+    return false
+  let depth = 0
+  for (let i = 0; i < v.length; i++) {
+    const c = v[i]
+    if (c === '\\') {
+      i++
+      continue
+    }
+    if (c === '[') {
+      // Skip character class — parens inside are literal.
+      i++
+      while (i < v.length && v[i] !== ']') {
+        if (v[i] === '\\')
+          i++
+        i++
+      }
+      continue
+    }
+    if (c === '(') {
+      depth++
+    }
+    else if (c === ')') {
+      depth--
+      if (depth === 0 && i !== v.length - 1)
+        return false
+    }
+  }
+  return depth === 0
+}
 
 export function wrap(s: string | Input<any>) {
   const v = s.toString()
-  return NO_WRAP_RE.test(v) ? v : `(?:${v})`
+  if (SINGLE_CHAR_RE.test(v) || isSingleGroup(v))
+    return v
+  return `(?:${v})`
 }

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -81,6 +81,16 @@ describe('inputs', () => {
       '/\\(\\?:foo\\(\\?<groupName>\\(\\?:foo\\)\\?\\)bar\\)\\?/',
     )
     expectTypeOf(extractRegExp(multi)).toEqualTypeOf<'(?:foo(?<groupName>(?:foo)?)bar)?'>()
+
+    // Regression for #549: maybe() must wrap the whole concatenation as a
+    // single optional group even when the last child is a named capture —
+    // previously `wrap()` treated `(?:[\-_.])?(?<number>\d+)` as "already
+    // grouped" because it started with `(` and ended with `)`, producing
+    // `(?:[\-_.])?(?<number>\d+)?` (only the final atom optional).
+    const withTrailingNamedCapture = maybe(charIn('-_.').optionally(), oneOrMore(digit).as('number'))
+    expect(new RegExp(withTrailingNamedCapture as any)).toMatchInlineSnapshot(
+      '/\\(\\?:\\(\\?:\\[\\\\-_\\.\\]\\)\\?\\(\\?<number>\\\\d\\+\\)\\)\\?/',
+    )
   })
   it('oneOrMore', () => {
     const input = oneOrMore('foo')


### PR DESCRIPTION
## Summary

Fixes #549 — \`maybe()\` / \`optionally()\` incorrectly handled named captures.

\`wrap()\` decided whether a value was already grouped via:

\`\`\`ts
const NO_WRAP_RE = /^(?:\(.*\)|\\?.)$/
\`\`\`

That check only looks at the first and last characters. A concatenation such as \`(?:[\-_.])?(?<number>\d+)\` starts with \`(\` and ends with \`)\` but is really two adjacent atoms, so \`wrap()\` skipped grouping it. The final \`?\` from \`maybe\` then bound to the trailing named capture alone:

\`\`\`
/(?:beta|dev)(?:[\-_.])?(?<number>\d+)?/gi   // before
/(?:beta|dev)(?:(?:[\-_.])?(?<number>\d+))?/gi // after
\`\`\`

Replaced the regex with a small balance-aware scan (\`isSingleGroup\`) that returns true only when the value is a single parenthesised group spanning from the first \`(\` to the last \`)\`. Character classes are skipped so literal \`[(]\` / \`[)]\` don't unbalance the count; escaped characters are also skipped.

## Test plan

- [x] Added a regression case in \`test/inputs.test.ts\` using the exact pattern from the issue.
- [x] \`pnpm test\` — 105/105 tests pass (inline snapshots for existing \`maybe\` / \`oneOrMore\` cases like \`maybe(exactly('foo').groupedAs('groupName'))\` → \`(?<groupName>foo)?\` unchanged).
- [x] \`pnpm lint\` clean.
- [x] Manual repro from the issue now matches \`Beta\` in \`-Beta.zip\` under both patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pattern wrapping behavior for complex regular expressions containing concatenations and parenthesized groups.

* **Tests**
  * Added regression test for optional group wrapping with named captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->