### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "magic-regexp",
   "version": "0.11.0",
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@11.20.0",
   "description": "A compiled-away, type-safe, readable RegExp alternative",
   "license": "MIT",
   "homepage": "https://regexp.dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,14 +18,12 @@ overrides:
   vite: 8.2.0
   vue: 3.5.29
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - shadcn-docs-nuxt
-  - unrs-resolver
-  - vue-demi
-
-onlyBuiltDependencies:
-  - '@tailwindcss/oxide'
-  - sharp
-  - simple-git-hooks
+allowBuilds:
+  '@parcel/watcher': false
+  '@tailwindcss/oxide': true
+  esbuild: false
+  shadcn-docs-nuxt: false
+  sharp: true
+  simple-git-hooks: true
+  unrs-resolver: false
+  vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Upgraded the package manager to version 11.20.0.
* Updated workspace build configuration to use explicit build permission settings while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->