### PR TITLE
fix(wrap): wrap adjacent groups before applying quantifiers

### DIFF
--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -48,6 +48,12 @@ type IsSingleGroup<S extends string> = S extends `(${infer Rest}`
   ? ScanGroup<Rest, [any]>
   : false
 
+/**
+ * Resolves to `No` when `Value` does not need wrapping before a quantifier is
+ * appended — i.e. it is a single character or a single group enclosing the
+ * whole string — and to `Yes` otherwise. This is the type-level counterpart of
+ * the runtime {@link isAtomic} check.
+ */
 export type IfUnwrapped<Value extends string, Yes, No> = IsSingleGroup<Value> extends true
   ? No
   : StripEscapes<Value> extends `${infer A}${infer B}`
@@ -114,6 +120,12 @@ function isAtomic(v: string): boolean {
   return depth === 0
 }
 
+/**
+ * Wraps a pattern in a non-capturing group (`(?:...)`) unless it is already
+ * atomic — a single character or a single group enclosing the whole string —
+ * so that a subsequently appended quantifier applies to the entire pattern.
+ * See {@link isAtomic} for the wrapping criteria.
+ */
 export function wrap(s: string | Input<any>) {
   const v = s.toString()
   return isAtomic(v) ? v : `(?:${v})`

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -1,7 +1,54 @@
 import type { Input } from './internal'
 import type { StripEscapes } from './types/escape'
 
-export type IfUnwrapped<Value extends string, Yes, No> = Value extends `(${string})`
+type Inc<T extends any[]> = [...T, any]
+type Dec<T extends any[]> = T extends [any, ...infer R] ? R : []
+
+/**
+ * Scans the contents of a character class (everything after a `[`), skipping
+ * escaped characters, until the closing `]`, then resumes group scanning.
+ */
+type ScanClass<S extends string, Depth extends any[]> = S extends `\\${string}${infer Rest}`
+  ? ScanClass<Rest, Depth>
+  : S extends `]${infer Rest}`
+    ? ScanGroup<Rest, Depth>
+    : S extends `${string}${infer Rest}`
+      ? ScanClass<Rest, Depth>
+      : false
+
+/**
+ * Walks the pattern (after an opening `(` has been consumed) tracking the
+ * parenthesis `Depth`, ignoring escaped characters and parens inside character
+ * classes. Resolves to `true` only if the group opened by the leading `(`
+ * closes exactly at the end of the string.
+ */
+type ScanGroup<S extends string, Depth extends any[]> = S extends `\\${string}${infer Rest}`
+  ? ScanGroup<Rest, Depth>
+  : S extends `[${infer Rest}`
+    ? ScanClass<Rest, Depth>
+    : S extends `(${infer Rest}`
+      ? ScanGroup<Rest, Inc<Depth>>
+      : S extends `)${infer Rest}`
+        ? Dec<Depth> extends []
+          ? Rest extends ''
+            ? true
+            : false
+          : ScanGroup<Rest, Dec<Depth>>
+        : S extends `${string}${infer Rest}`
+          ? ScanGroup<Rest, Depth>
+          : false
+
+/**
+ * Resolves to `true` if the whole pattern is a single group enclosing the
+ * entire string, e.g. `(?:a|b)` or `(?<name>\d+)`. Adjacent groups such as
+ * `(?:a|b)(?:1|2)` resolve to `false`, since a trailing quantifier would
+ * otherwise only apply to the last group.
+ */
+type IsSingleGroup<S extends string> = S extends `(${infer Rest}`
+  ? ScanGroup<Rest, [any]>
+  : false
+
+export type IfUnwrapped<Value extends string, Yes, No> = IsSingleGroup<Value> extends true
   ? No
   : StripEscapes<Value> extends `${infer A}${infer B}`
     ? A extends ''
@@ -11,9 +58,63 @@ export type IfUnwrapped<Value extends string, Yes, No> = Value extends `(${strin
         : Yes
     : never
 
-const NO_WRAP_RE = /^(?:\(.*\)|\\?.)$/
+const SINGLE_CHAR_RE = /^\\?.$/
+
+/**
+ * Returns `true` if the pattern is a single token that does not need to be
+ * wrapped in a non-capturing group before a quantifier (`?`, `+`, `*`, `{n}`)
+ * is appended.
+ *
+ * This is the case when the pattern is either:
+ * - a single (optionally escaped) character, e.g. `a` or `\.`, or
+ * - a single group that encloses the entire pattern, e.g. `(?:a|b)` or
+ *   `(?<name>\d+)`.
+ *
+ * Adjacent groups such as `(?:a|b)(?:1|2)` must still be wrapped, since a
+ * trailing quantifier would otherwise only apply to the last group.
+ */
+function isAtomic(v: string): boolean {
+  if (SINGLE_CHAR_RE.test(v))
+    return true
+
+  // Must be enclosed in parentheses to be a single group.
+  if (v[0] !== '(' || v[v.length - 1] !== ')')
+    return false
+
+  // Walk the string tracking parenthesis depth, ignoring escaped characters
+  // and parens inside character classes. If the depth returns to 0 before the
+  // final character, the pattern is made up of multiple top-level tokens and
+  // therefore needs wrapping (e.g. `(?:a|b)(?:1|2)`).
+  let depth = 0
+  let inClass = false
+  for (let i = 0; i < v.length; i++) {
+    const c = v[i]
+    if (c === '\\') {
+      i++
+      continue
+    }
+    if (inClass) {
+      if (c === ']')
+        inClass = false
+      continue
+    }
+    if (c === '[') {
+      inClass = true
+    }
+    else if (c === '(') {
+      depth++
+    }
+    else if (c === ')') {
+      depth--
+      if (depth === 0 && i !== v.length - 1)
+        return false
+    }
+  }
+
+  return depth === 0
+}
 
 export function wrap(s: string | Input<any>) {
   const v = s.toString()
-  return NO_WRAP_RE.test(v) ? v : `(?:${v})`
+  return isAtomic(v) ? v : `(?:${v})`
 }

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -81,6 +81,27 @@ describe('inputs', () => {
       '/\\(\\?:foo\\(\\?<groupName>\\(\\?:foo\\)\\?\\)bar\\)\\?/',
     )
     expectTypeOf(extractRegExp(multi)).toEqualTypeOf<'(?:foo(?<groupName>(?:foo)?)bar)?'>()
+
+    // a single enclosing group must not be double-wrapped
+    const singleGroup = maybe(exactly('a').or('b'))
+    expect(new RegExp(singleGroup as any)).toMatchInlineSnapshot('/\\(\\?:a\\|b\\)\\?/')
+    expectTypeOf(extractRegExp(singleGroup)).toEqualTypeOf<'(?:a|b)?'>()
+
+    // adjacent groups must be wrapped as a whole so `?` applies to all of them
+    // https://github.com/unjs/magic-regexp/issues/505
+    const adjacentGroups = maybe(exactly('a').or('b'), exactly('1').or('2'))
+    expect(new RegExp(adjacentGroups as any)).toMatchInlineSnapshot(
+      '/\\(\\?:\\(\\?:a\\|b\\)\\(\\?:1\\|2\\)\\)\\?/',
+    )
+    expectTypeOf(extractRegExp(adjacentGroups)).toEqualTypeOf<'(?:(?:a|b)(?:1|2))?'>()
+
+    // adjacent groups including a named capture group
+    // https://github.com/unjs/magic-regexp/issues/549
+    const withNamedGroup = maybe(charIn('-_.').optionally(), oneOrMore(digit).as('number'))
+    expect(new RegExp(withNamedGroup as any)).toMatchInlineSnapshot(
+      '/\\(\\?:\\(\\?:\\[\\\\-_\\.\\]\\)\\?\\(\\?<number>\\\\d\\+\\)\\)\\?/',
+    )
+    expectTypeOf(extractRegExp(withNamedGroup)).toEqualTypeOf<'(?:(?:[\\-_.])?(?<number>\\d+))?'>()
   })
   it('oneOrMore', () => {
     const input = oneOrMore('foo')


### PR DESCRIPTION
## Summary

`maybe()`, `optionally()`, `oneOrMore()` and `times.*()` all rely on `wrap()` to decide whether a pattern needs a non-capturing group before a quantifier (`?`, `+`, `*`, `{n}`) is appended.

The previous check treated **any** pattern that starts with `(` and ends with `)` as a single atomic group:

- runtime: `NO_WRAP_RE = /^(?:\(.*\)|\\?.)$/`
- type level: `Value extends \`(\${string})\``

That is incorrect for **adjacent** groups, where the pattern starts with `(` and ends with `)` but is actually made of more than one top-level group. The quantifier then only applies to the **last** group instead of the whole thing:

```ts
// before
maybe(exactly('a').or('b'), exactly('1').or('2'))
// => /(?:a|b)(?:1|2)?/   ❌  '?' only applies to (?:1|2)

maybe(charIn('-_.').optionally(), oneOrMore(digit).as('number'))
// => /(?:[\-_.])?(?<number>\d+)?/   ❌
```

## Fix

Replace the naive start/end check with a balanced-parenthesis scan — implemented both at runtime (`isAtomic`) and at the type level (`IsSingleGroup`) so the generated source string and its literal type stay in sync. Wrapping is only skipped when a single group encloses the **entire** pattern. Escaped characters and parentheses inside character classes are handled correctly.

```ts
// after
maybe(exactly('a').or('b'), exactly('1').or('2'))
// => /(?:(?:a|b)(?:1|2))?/   ✅

maybe(charIn('-_.').optionally(), oneOrMore(digit).as('number'))
// => /(?:(?:[\-_.])?(?<number>\d+))?/   ✅
```

Single enclosing groups are still left unwrapped (no double-wrapping):

```ts
maybe(exactly('a').or('b')) // => /(?:a|b)?/   ✅ unchanged
```

## Tests

Added cases to `test/inputs.test.ts` covering single groups, adjacent groups, and adjacent groups containing a named capture group, asserting both the runtime `RegExp` and the literal type output.

- `pnpm test` — 105 passed
- `pnpm test:types` (tsc) — no errors
- vitest `--typecheck` — no errors
- `pnpm lint` — clean
- `pnpm build` — ok

Fixes #549
Fixes #505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pattern-wrapping logic to avoid re-wrapping expressions that should already be treated as atomic, especially for parenthesized groups and edge cases involving escaped characters.
  * Corrected `maybe(...)` optional quantifier behavior for grouped inputs, including scenarios with adjacent groups and named captures, ensuring the resulting regex and extracted types match expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->